### PR TITLE
[Feature] 사용자는 인터뷰를 시작할 수 있다.

### DIFF
--- a/packages/backend/db/seeds.sql
+++ b/packages/backend/db/seeds.sql
@@ -1,0 +1,330 @@
+-- 1. Users
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (1, 'test@example.com', 'https://example.com/profile.jpg', NOW(), NOW());
+
+-- 2. Documents (Cover Letter & Portfolio)
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (1, 'COVER', 'Frontend Dev Cover Letter', NOW(), 1);
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (2, 'PORTFOLIO', 'Fullstack Portfolio', NOW(), 1);
+
+-- 3. Cover Letter Details
+INSERT INTO cover_letters (cover_letters_id, documents_id)
+VALUES (1, 1);
+
+INSERT INTO cover_letters_question_answer (cover_letters_question_answer_id, question, answer, cover_letter_id)
+VALUES (1, '지원 동기가 무엇인가요?', '사용자에게 편리한 경험을 제공하는 서비스를 만들고 싶습니다.', 1);
+
+-- 4. Portfolio Details (updated to use content from ENV)
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (1, '개발 스킬/환경
+	•	Java: TDD, OOP, MVC 이해 및 적용 / 일급 컬렉션·Enum·record 활용 / 입력 검증·책임 분리 설계
+	•	Spring / Spring Boot: MSA 구조 설계, REST API, JPA, 트랜잭션 처리, JWT 인증 구현, WebSocket·SSE 등 실시간 통신 학습/적용
+	•	Kafka: Producer–Consumer 구조, Topic·Partition 구성 이해 / KRaft 모드 Kafka 클러스터 구축/운영 경험
+	•	Redis: Pub/Sub 기반 메시지 처리 / 싱글 스레드 구조 및 key-value 자료구조 이해·활용
+	•	기타: Python(Django/DRF), PostgreSQL·MongoDB, AWS(EC2/RDS/S3/Route53), Docker/Docker-Compose
+	•	협업 도구: GitHub, Figma, Notion, StarUML
+
+⸻
+
+프로젝트 요약
+
+1) SmileTogether (2025.01 ~ 2025.03)
+	•	역할: 팀장 + 백엔드 개발
+	•	목표: 팀 기반 협업용 메신저 플랫폼, 실시간 커뮤니케이션 + 대용량 트래픽 대응
+	•	구성/기여
+	•	MSA 기반 서버 아키텍처 및 DB 설계
+	•	유저(멤버)·이메일 서버 구현, 내부 서비스 간 HTTP 통신(RestTemplate)
+	•	WebSocket + STOMP 기반 채팅 기능 개발/고도화, 다중 채팅 서버로 연결 부하 분산
+	•	Kafka 메시지 브로커로 다중 채팅 서버 간 동기화
+	•	히스토리(메시지 보관) 서버 분리 후 Kafka 기반 채팅 데이터 CRUD 비동기 처리
+	•	채널 ID를 Key로 해싱해 동일 파티션 매핑 → 메시지 순서 보장
+	•	채팅 데이터 저장에 MongoDB(JSON 문서) 도입
+	•	STOMP 인바운드 채널 Interceptor로 디버깅 로그/연동
+	•	KRaft 모드 Kafka 클러스터(3 broker + 1 controller) 구성, Kafka UI 활용, Docker-Compose 기반 재현/운영
+	•	협업 방식/리딩
+	•	데일리 스크럼·코어타임 운영, 업무 분담 및 PMP 문서 작성, PR 알림 자동화 제안
+
+2) FaceFriend (2024.01 ~ 2024.05/06)
+	•	역할: 백엔드 개발
+	•	프로젝트 소개: AI 이미지 생성/관상 분석 기반의 데이팅 서비스(새로운 매칭 경험)
+	•	구성/기여
+	•	Spring + AWS(RDS/S3/EC2) 기반 서버 아키텍처 설계/구현
+	•	WebSocket + STOMP로 하트 요청/수락·거절 및 채팅 실시간 처리
+	•	Redis를 STOMP **외부 메시지 브로커(Pub/Sub)**로 활용
+	•	비연결(미접속) 상태 메시지 손실 대응: 사용자 앱 접속 정보 관리 → 접속 여부에 따라 송신/저장 분기, Redis에 저장/관리
+	•	채팅방 생성/조회/삭제, 메시지 조회 API 구현
+	•	Docker/Docker-Compose로 테스트 환경 구축, AWS 배포
+	•	StompHeaderAccessor + JWT Provider로 WebSocket(STOMP) 헤더 JWT 검증/정보 추출
+
+3) OneHabit (2024.03)
+	•	역할: 기획 및 백엔드 개발(포트폴리오 서술)
+	•	내용
+	•	습관 생성/조회/삭제/리스트 API
+	•	인증 시 경험치/성장 로직
+	•	하루 인증 3회 제한, 중복 인증 처리 방지
+	•	매일 자정 인증 데이터 초기화/연속 기록 초기화(스케줄러 활용)
+
+4) Moyeo (2023.07 ~ 2023.08, Django)
+	•	Swagger로 API 명세 자동화
+	•	모임 CRUD, 등급 자동 승급(크론 기반)
+	•	태그 기반 추천 API(필터링/제외 조건/종료일 고려/예외 시 랜덤)
+	•	태그 모델 통합 리팩토링
+
+5) Relanz (2023.06 ~ 2023.07, Django)
+	•	인증(회원/로그인/로그아웃)
+	•	태그 기반 추천, 아바타 커스터마이징, 스코어(랭킹)
+	•	Nginx + Gunicorn + EC2 배포
+
+6) KiKi_Kiosk (프로젝트 서술 포함)
+	•	요구사항 분석 및 시스템 구조 설계
+	•	관리자 로그인/로그아웃 구현
+	•	비즈니스 로직 분리 및 유지보수 용이성 향상을 위한 설계 패턴 적용
+	•	GRASP 원칙 및 디자인 패턴(Controller/Creator/Expert/Singleton/DTO 등) 적용
+	•	AWS EC2 배포, Docker-Compose 기반 간단 배포 환경 구축
+
+⸻
+
+학습/대외활동/협업 경험
+	•	S사 Online Dev Camp (2024.10 ~ 2025.11): Java 백엔드 지원(포트폴리오 서술)
+	•	W사 부트캠프 프리코스 경험(포트폴리오 서술)
+	•	TDD/OOP/MVC 이해 증대 및 적용 시도
+	•	Spring 프레임워크 없이 Java만으로 과제 수행하며 Java 자체 학습
+	•	Stream/람다 등으로 코드 간결화, 읽기 쉬운 코드에 대한 학습
+	•	동아리/해커톤
+	•	웹 개발 및 IT 창업 동아리 활동(2023~2024)
+	•	교내/중앙 해커톤 참여(2023)
+	•	약 40명 규모 동아리 대표(2024)
+	•	동아리 연합 해커톤 중앙운영단 참여(2024)
+	•	G사 해커톤 2기 활동(2024) 및 약 300명 규모 해커톤 참여(벚꽃톤)
+
+⸻
+
+학력
+	•	OO대학교 한국역사학과 학사 (2019~2025) 졸업
+	•	OO대학교 소프트웨어전공 학사 (2022~2025) 복수학위 졸업
+
+⸻
+
+논문/수상
+	•	논문(2024-06-26, 한국정보과학회 학술발표논문집)
+	•	모바일 환경에서 JWT 토큰 관리로 사용자 개인정보 보안
+	•	재난 애플리케이션 특성을 고려한 토큰 발급/재발급 과정 서술
+	•	토큰 기반 시스템 백엔드 서버 구현 서술
+	•	수상
+	•	IT 연합 동아리 X OO대 해커톤 금상
+	•	2024 한국컴퓨터종합학술대회 학부생/주니어 논문경진대회 장려상
+', 1);
+
+-- 5. AI Persona
+INSERT INTO ai_persona (persona_id, prompt, name, img_url)
+VALUES ('p1', '당신은 날카롭지만 따뜻한 면접관입니다.', 'Tech Interviewer', 'https://example.com/persona.jpg');
+
+-- 6. Interview (Tech Type)
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id)
+VALUES (1, 'Boostcamp Web Interview', 'TECH', NOW(), 'NONE', NOW(), 1);
+
+-- 7. Technical Interview Details
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (1, '', '', 1);
+
+-- 8. Interview Documents (Linking Interview to Docs)
+-- Link Cover Letter
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (1, NOW(), NOW(), 1, 1);
+
+-- Link Portfolio
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (2, NOW(), NOW(), 1, 2);
+
+
+-- ==========================================
+-- Additional Users (Requested)
+-- ==========================================
+
+-- User 2: Backend (Java)
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (2, 'java_dev@example.com', 'https://example.com/profile_java.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (3, 'PORTFOLIO', 'Java Backend Developer Portfolio', NOW(), 2);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (2, '기술 스택
+	•	Java, Spring Boot, JPA, QueryDSL, MySQL, Redis, AWS
+	•	JUnit5, Mockito, Gradle
+
+프로젝트 경험
+
+1) 대규모 이커머스 플랫폼 리팩토링 (2024.06 ~ 2024.12)
+	•	역할: 백엔드 리드
+	•	내용: 레거시 모놀리식 아키텍처를 MSA로 전환
+	•	성과: 주문 처리 속도 50% 향상, 트래픽 피크 시 안정성 확보
+	•	상세 기술:
+		- Spring Cloud Gateway 및 Eureka 적용
+		- Kafka를 이용한 주문-배송 서비스 간 비동기 이벤트 처리
+		- Redis 캐싱을 통한 상품 조회 성능 최적화
+
+2) 사내 예약 시스템 고도화 (2023.09 ~ 2024.05)
+	•	역할: 백엔드 개발자
+	•	내용: 회의실 및 장비 예약 시스템 기능 개선 및 동시성 제어
+	•	상세 기술:
+		- Redisson 분산 락을 도입하여 중복 예약 문제 해결
+		- QueryDSL을 활용한 복잡한 동적 쿼리 구현
+', 3);
+
+
+-- User 3: Backend (Python)
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (3, 'python_dev@example.com', 'https://example.com/profile_python.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (4, 'PORTFOLIO', 'Python Backend Developer Portfolio', NOW(), 3);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (3, '기술 스택
+	•	Python, Django, FastAPI, PostgreSQL, Celery, Redis, Docker
+	•	Pandas, NumPy (데이터 처리 기초)
+
+프로젝트 경험
+
+1) 실시간 데이터 분석 대시보드 API (2024.03 ~ 2024.09)
+	•	역할: 백엔드 개발 및 데이터 파이프라인 구축
+	•	내용: IoT 센서 데이터를 수집하여 시각화하는 대시보드 백엔드 구축
+	•	상세 기술:
+		- FastAPI의 비동기 처리를 활용하여 초당 1000건 이상의 데이터 수집
+		- Celery와 Redis를 이용한 무거운 데이터 집계 작업 비동기 처리
+		- TimescaleDB (PostgreSQL 확장)를 활용한 시계열 데이터 저장 최적화
+
+2) 소셜 네트워크 서비스 백엔드 (2023.08 ~ 2024.02)
+	•	역할: 백엔드 개발자
+	•	내용: 사용자 피드 및 알림 기능 구현
+	•	상세 기술:
+		- Django REST Framework (DRF) 기반 API 설계
+		- Django Channels를 이용한 실시간 알림 기능 구현 (WebSocket)
+', 4);
+
+
+-- User 4: Frontend (React/Next.js)
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (4, 'frontend_react@example.com', 'https://example.com/profile_react.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (5, 'PORTFOLIO', 'React Frontend Developer Portfolio', NOW(), 4);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (4, '기술 스택
+	•	React, Next.js, TypeScript, TailwindCSS, Recoil, React Query
+	•	Storybook, Jest, Testing Library
+
+프로젝트 경험
+
+1) 암호화폐 거래소 모바일 웹 리뉴얼 (2024.05 ~ 2024.11)
+	•	역할: 프론트엔드 개발자
+	•	내용: 모바일 사용자 경험 최적화를 위한 UI/UX 전면 개편
+	•	상세 기술:
+		- Next.js의 SSR/ISR을 활용하여 초기 로딩 속도 40% 개선
+		- WebSocket을 이용한 실시간 시세 차트 컴포넌트 구현 (Lightweight Charts 활용)
+		- Recoil을 이용한 전역 상태 관리 및 테마(Dark Mode) 적용
+
+2) 기업용 랜딩 페이지 빌더 (2023.11 ~ 2024.04)
+	•	역할: 프론트엔드 개발자
+	•	내용: 드래그 앤 드롭으로 랜딩 페이지를 제작할 수 있는 도구 개발
+	•	상세 기술:
+		- React DND 라이브러리를 활용한 드래그 앤 드롭 인터페이스 구현
+		- 컴포넌트 재사용성을 위한 아토믹 디자인 패턴 적용
+', 5);
+
+
+-- User 5: Frontend (Vue/Nuxt)
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (5, 'frontend_vue@example.com', 'https://example.com/profile_vue.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (6, 'PORTFOLIO', 'Vue Frontend Developer Portfolio', NOW(), 5);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (5, '기술 스택
+	•	Vue.js 3, Nuxt.js, Pinia, Sass(SCSS), Vuetify
+	•	Cypress (E2E Test)
+
+프로젝트 경험
+
+1) 물류 관리 어드민 대시보드 (2024.02 ~ 2024.08)
+	•	역할: 프론트엔드 개발자
+	•	내용: 복잡한 물류 데이터를 관리하고 시각화하는 내부 시스템 구축
+	•	상세 기술:
+		- Vue 3 Composition API를 활용한 로직 재사용성 증대
+		- Ag-Grid와 같은 고성능 데이터 그리드 라이브러리 커스터마이징
+		- Pinia를 활용한 효율적인 상태 관리 및 모듈화
+
+2) 개발자 커뮤니티 포럼 (2023.07 ~ 2024.01)
+	•	역할: 프론트엔드 개발자
+	•	내용: 마크다운 에디터와 댓글 기능을 포함한 커뮤니티 사이트 개발
+	•	상세 기술:
+		- Nuxt 3를 이용한 SEO 최적화 및 서버 사이드 렌더링
+		- Toast UI Editor 커스터마이징 및 이미지 업로드 처리
+', 6);
+
+
+-- User 6: Fullstack (Node/JS/TS)
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (6, 'fullstack_js@example.com', 'https://example.com/profile_fullstack.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (7, 'PORTFOLIO', 'Fullstack Developer Portfolio', NOW(), 6);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (6, '기술 스택
+	•	JavaScript(ES6+), TypeScript, Node.js, NestJS, React, MongoDB
+	•	Express, Mongoose, Socket.io
+
+프로젝트 경험
+
+1) 실시간 협업 화이트보드 서비스 (2024.04 ~ 2024.10)
+	•	역할: 풀스택 개발 (개인 프로젝트)
+	•	내용: 여러 사용자가 동시에 그림을 그리고 채팅할 수 있는 웹 서비스
+	•	상세 기술:
+		- (BE) NestJS + Socket.io gateway를 이용한 실시간 양방향 통신 구현
+		- (FE) HTML5 Canvas API 및 React를 활용한 드로잉 보드 구현
+		- (DB) MongoDB Atlas를 이용한 드로잉 히스토리 저장 (비정형 데이터 처리)
+
+2) 기술 블로그 플랫폼 (2023.10 ~ 2024.03)
+	•	역할: 풀스택 개발자
+	•	내용: Next.js 기반의 프론트엔드와 NestJS 기반의 백엔드를 통합한 블로그
+	•	상세 기술:
+		- Monorepo(Turborepo) 환경 구축하여 FE/BE 코드 통합 관리
+		- JWT 기반 인증/인가 시스템 구현 (Access/Refresh Token)
+', 7);
+
+
+-- User 7: DevOps
+INSERT INTO users (user_id, user_email, profile_url, created_at, modified_at)
+VALUES (7, 'devops@example.com', 'https://example.com/profile_devops.jpg', NOW(), NOW());
+
+INSERT INTO documents (documents_id, type, title, created_at, user_id)
+VALUES (8, 'PORTFOLIO', 'DevOps Engineer Portfolio', NOW(), 7);
+
+INSERT INTO portfolios (portfolios_id, content, documents_id)
+VALUES (7, '기술 스택
+	•	AWS, Docker, Kubernetes, Jenkins, GitHub Actions, Terraform
+	•	Prometheus, Grafana, ELK Stack, Linux(Ubuntu/CentOS)
+
+프로젝트 경험
+
+1) 금융 서비스 클라우드 마이그레이션 및 자동화 (2024.01 ~ 2024.07)
+	•	역할: DevOps 엔지니어
+	•	내용: 온프레미스 환경의 서비스를 AWS 클라우드 환경으로 이관 및 파이프라인 구축
+	•	상세 기술:
+		- Terraform(IaC)을 활용한 AWS 인프라(VPC, EC2, RDS, EKS) 프로비저닝 자동화
+		- Jenkins 기반의 CI/CD 파이프라인 구축 (Blue/Green 배포 전략 적용)
+		- Kubernetes(EKS) 클러스터 구축 및 MSA 서비스 배포 관리
+
+2) 모니터링 시스템 통합 구축 (2023.05 ~ 2023.12)
+	•	역할: DevOps 엔지니어
+	•	내용: 서비스 장애 감지 및 성능 모니터링을 위한 통합 관제 시스템 구축
+	•	상세 기술:
+		- Prometheus + Grafana를 이용한 시스템 리소스(CPU, Memory) 및 애플리케이션 메트릭 시각화
+		- ELK Stack (Elasticsearch, Logstash, Kibana)을 이용한 중앙 집중형 로그 관리 시스템 구축
+', 8);

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './auth/auth.module';
 import { DocumentModule } from './document/document.module';
 import { InterviewModule } from './interview/interview.module';
 import { UserModule } from './user/user.module';
+import { SeedModule } from './seed/seed.module';
 
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -37,6 +38,7 @@ import { winstonOptions } from './common/logger/winston.config';
     AuthModule,
     DocumentModule,
     InterviewModule,
+    SeedModule,
   ],
   controllers: [],
   providers: [],

--- a/packages/backend/src/document/document.module.ts
+++ b/packages/backend/src/document/document.module.ts
@@ -3,10 +3,16 @@ import { DocumentController } from './document.controller';
 import { DocumentService } from './document.service';
 import { PortfolioRepository } from './repositories/portfolio.repository';
 import { CoverLetterRepository } from './repositories/cover-letter.repository';
+import { DocumentRepository } from './repositories/document.repository';
 
 @Module({
   controllers: [DocumentController],
-  providers: [DocumentService, PortfolioRepository, CoverLetterRepository],
-  exports: [PortfolioRepository, CoverLetterRepository],
+  providers: [
+    DocumentService,
+    PortfolioRepository,
+    CoverLetterRepository,
+    DocumentRepository,
+  ],
+  exports: [PortfolioRepository, CoverLetterRepository, DocumentRepository],
 })
 export class DocumentModule {}

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, In, Repository } from 'typeorm';
+import { Document } from '../entities/document.entity';
+
+@Injectable()
+export class DocumentRepository extends Repository<Document> {
+  constructor(dataSource: DataSource) {
+    super(Document, dataSource.createEntityManager());
+  }
+
+  async findByIds(ids: string[]): Promise<Document[]> {
+    return this.find({
+      where: {
+        documentId: In(ids),
+      },
+    });
+  }
+}

--- a/packages/backend/src/interview/dto/create-interview-request.dto.ts
+++ b/packages/backend/src/interview/dto/create-interview-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsArray, IsString } from 'class-validator';
+
+export class CreateInterviewRequestDto {
+  @IsArray()
+  @IsString({ each: true })
+  documentIds: string[];
+}

--- a/packages/backend/src/interview/dto/create-interview-response.dto.ts
+++ b/packages/backend/src/interview/dto/create-interview-response.dto.ts
@@ -1,0 +1,6 @@
+export class CreateInterviewResponseDto {
+  interviewId: string;
+  questionId: string;
+  question: string;
+  createdAt: Date;
+}

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -18,9 +18,21 @@ import { InterviewChatHistoryResponse } from './dto/interview-chat-history-respo
 import { InterviewQuestionRequest } from './dto/interview-question-request.dto';
 import { InterviewQuestionResponse } from './dto/interview-question-response.dto';
 
+import { CreateInterviewRequestDto } from './dto/create-interview-request.dto';
+import { CreateInterviewResponseDto } from './dto/create-interview-response.dto';
+
 @Controller('interview')
 export class InterviewController {
   constructor(private readonly interviewService: InterviewService) { }
+
+  @Post('tech/create')
+  async createTechInterview(
+    @Body() body: CreateInterviewRequestDto,
+  ): Promise<CreateInterviewResponseDto> {
+    // 인증이 없기 때문에 userId를 상수화
+    const userId = '1';
+    return await this.interviewService.createTechInterview(userId, body);
+  }
 
   @Post('answer/voice')
   @UseInterceptors(FileInterceptor('file'))
@@ -61,7 +73,6 @@ export class InterviewController {
 
   @Get('/:interviewId/chat/history')
   async getInterviewChatHistory(
-
     @Param('interviewId') interviewId: string
   ): Promise<InterviewChatHistoryResponse> {
     // 인증이 없기 때문에 userId를 상수화

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -13,11 +13,14 @@ import { InterviewAIService } from './interview-ai.service';
 import { SttService } from './stt.service';
 import { InterviewRepository } from './interview.repository';
 import { Interview } from './entities/interview.entity';
-import { SttService } from './stt.service';
-import { InterviewAnswer } from './entities/interview-answer.entity';
 import { InterviewChatHistoryResponse } from './dto/interview-chat-history-response.dto';
 import { PortfolioRepository } from '../document/repositories/portfolio.repository';
 import { CoverLetterRepository } from '../document/repositories/cover-letter.repository';
+import { CreateInterviewResponseDto } from './dto/create-interview-response.dto';
+import { InterviewType, LikeStatus } from './entities/interview.entity';
+import { CreateInterviewRequestDto } from './dto/create-interview-request.dto';
+import { DocumentRepository } from '../document/repositories/document.repository';
+import { User } from '../user/entities/user.entity';
 
 @Injectable()
 export class InterviewService {
@@ -32,7 +35,55 @@ export class InterviewService {
     private readonly interviewAIService: InterviewAIService,
     private readonly portfolioRepository: PortfolioRepository,
     private readonly coverLetterRepository: CoverLetterRepository,
+    private readonly documentRepository: DocumentRepository,
   ) {}
+
+  async createTechInterview(
+    userId: string,
+    dto: CreateInterviewRequestDto,
+  ): Promise<CreateInterviewResponseDto> {
+    // 1. Interview 엔티티 생성
+    const interview = new Interview();
+    interview.title = 'Tech Interview'; // 기본 타이틀
+    interview.type = InterviewType.TECH;
+    interview.likeStatus = LikeStatus.NONE;
+    interview.duringTime = new Date(); // 기본값으로 현재 시간 설정
+    interview.user = { userId } as User; // 관계 설정을 위해 ID만 할당 (User entity 전체 로드 불필요 시)
+
+    const savedInterview = await this.interviewRepository.save(interview);
+    const interviewId = savedInterview.interviewId;
+
+    // 2. 초기 데이터 (Portfolio/CoverLetter 등) 준비 및 Redis(KeySetStore) 저장
+    const documentsKey = `documents:${interviewId}`;
+
+    if (dto.documentIds && dto.documentIds.length > 0) {
+      const documents = await this.documentRepository.findByIds(
+        dto.documentIds,
+      );
+
+      documents.forEach((doc) => {
+        // DocumentType이 'PORTFOLIO', 'COVER' 등과 일치한다고 가정
+        // Redis 저장 포맷: TYPE:ID (예: PORTFOLIO:1)
+        this.keySetStore.addToSet(
+          documentsKey,
+          `${doc.type}:${doc.documentId}`,
+        );
+        this.logger.log(
+          `Added document to MemoryStore: ${doc.type}:${doc.documentId}`,
+        );
+      });
+    }
+
+    // 3. 첫 질문 생성
+    const firstQuestion = await this.chatInterviewer(interviewId);
+
+    return {
+      interviewId: interviewId,
+      questionId: firstQuestion.questionId,
+      question: firstQuestion.question,
+      createdAt: firstQuestion.createdAt,
+    };
+  }
 
   async answerWithVoice(
     userId: string,
@@ -84,14 +135,20 @@ export class InterviewService {
     return interview;
   }
 
-  async findInterviewChatHistory(userId: string, interviewId: string): Promise<InterviewChatHistoryResponse> {
+  async findInterviewChatHistory(
+    userId: string,
+    interviewId: string,
+  ): Promise<InterviewChatHistoryResponse> {
     const interview = await this.findExistingInterview(interviewId, [
       'answers',
       'user',
-      'questions'
+      'questions',
     ]);
     interview.validateUser(userId);
-    return InterviewChatHistoryResponse.fromEntity(interview.answers, interview.questions);
+    return InterviewChatHistoryResponse.fromEntity(
+      interview.answers,
+      interview.questions,
+    );
   }
 
   async chatInterviewer(interviewId: string) {
@@ -104,9 +161,6 @@ export class InterviewService {
     this.logger.log('answers:', JSON.stringify(answers, null, 2));
 
     const documentsKey = `documents:${interviewId}`;
-
-    // 테스트를 위한 하드 코딩
-    this.keySetStore.addToSet(documentsKey, 'PORTFOLIO:1');
 
     const documentIds = this.keySetStore.getSet(documentsKey);
 

--- a/packages/backend/src/interview/stores/key-set.store.ts
+++ b/packages/backend/src/interview/stores/key-set.store.ts
@@ -1,20 +1,62 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { MinHeapScheduler } from './min-heap.scheduler';
 
 @Injectable()
-export class KeySetStore {
+export class KeySetStore implements OnModuleInit {
   private readonly store = new Map<string, Set<string>>();
+  // TTL 관리를 위한 Min-Heap 스케줄러
+  private readonly scheduler = new MinHeapScheduler();
+  private readonly logger = new Logger(KeySetStore.name);
 
   /**
-   * Add a value to the set identified by key.
+   * 모듈 초기화 시 cleanup 타이머 시작
+   */
+  onModuleInit() {
+    // 5초마다 만료된 키 확인
+    setInterval(() => {
+      this.cleanupExpiredKeys();
+    }, 5000);
+  }
+
+  /**
+   * 스케줄러를 확인하여 만료된 키를 스토어에서 제거
+   */
+  private cleanupExpiredKeys() {
+    const now = Date.now();
+    while (true) {
+      const task = this.scheduler.peek();
+      if (!task || task.executeAt > now) break;
+
+      // 만료된 작업 꺼내기
+      const expired = this.scheduler.pop();
+      if (expired) {
+        // 해당 키의 데이터 삭제
+        this.logger.log(`Removing expired key: ${expired.key}`);
+        this.clear(expired.key);
+      }
+    }
+  }
+
+  /**
    * @param key The key to identify the set (e.g., interviewId).
    * @param value The value to add to the set (e.g., topic or question).
+   * @param ttl Optional TTL in milliseconds. Default is 40 minutes (2400000ms).
    */
-  addToSet(key: string, value: string): void {
+  addToSet(key: string, value: string, ttl: number = 40 * 60 * 1000): void {
     if (!this.store.has(key)) {
       this.store.set(key, new Set<string>());
     }
     this.store.get(key)?.add(value);
+
+    // TTL이 0이거나 음수면 스케줄링 하지 않음 (필요 시 정책 조정)
+    if (ttl > 0) {
+      // 기존 스케줄 제거 후 새로 등록 (TTL 갱신)
+      // 스케줄러는 O(log N)으로 동작하므로 무거운 연산 아님
+      this.scheduler.remove(key);
+      this.scheduler.push(key, Date.now() + ttl);
+    }
   }
+
   /**
    * Get all values from the set identified by key.
    * @param key The key to identify the set.
@@ -49,5 +91,7 @@ export class KeySetStore {
    */
   clear(key: string): void {
     this.store.delete(key);
+    // 스케줄러에서도 제거
+    this.scheduler.remove(key);
   }
 }

--- a/packages/backend/src/interview/stores/min-heap.scheduler.ts
+++ b/packages/backend/src/interview/stores/min-heap.scheduler.ts
@@ -1,0 +1,103 @@
+export interface ScheduledTask {
+  key: string;
+  executeAt: number;
+}
+
+export class MinHeapScheduler {
+  private heap: ScheduledTask[] = [];
+
+  public push(key: string, executeAt: number): void {
+    const task: ScheduledTask = { key, executeAt };
+    this.heap.push(task);
+    this.bubbleUp(this.heap.length - 1);
+  }
+
+  public pop(): ScheduledTask | undefined {
+    if (this.heap.length === 0) return undefined;
+
+    const root = this.heap[0];
+    const last = this.heap.pop();
+
+    if (this.heap.length > 0 && last) {
+      this.heap[0] = last;
+      this.trickleDown(0);
+    }
+
+    return root;
+  }
+
+  public peek(): ScheduledTask | undefined {
+    return this.heap.length > 0 ? this.heap[0] : undefined;
+  }
+
+  public remove(key: string): void {
+    const index = this.heap.findIndex((task) => task.key === key);
+    if (index === -1) return;
+
+    // 만약 제거하려는 요소가 마지막 요소라면 그냥 pop
+    if (index === this.heap.length - 1) {
+      this.heap.pop();
+      return;
+    }
+
+    // 마지막 요소를 제거하려는 위치로 가져옴
+    const last = this.heap.pop();
+    if (last) {
+      this.heap[index] = last;
+      // 위치 변경 후 정렬 조건 유지를 위해 위/아래로 이동 확인
+      this.bubbleUp(index);
+      this.trickleDown(index);
+    }
+  }
+
+  public get size(): number {
+    return this.heap.length;
+  }
+
+  private bubbleUp(index: number): void {
+    const element = this.heap[index];
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2);
+      const parent = this.heap[parentIndex];
+
+      if (element.executeAt >= parent.executeAt) break;
+
+      this.heap[index] = parent;
+      this.heap[parentIndex] = element;
+      index = parentIndex;
+    }
+  }
+
+  private trickleDown(index: number): void {
+    const length = this.heap.length;
+    const element = this.heap[index];
+
+    // 무한 루프처럼 보이지만, 트리 높이(log N)만큼만 반복되므로 성능 이슈 없음.
+    // 힙의 속성(부모 노드가 자식 노드보다 항상 작아야 함)을 만족시키기 위해
+    // 현재 요소를 적절한 위치로 내려보냄.
+    while (true) {
+      let swapIndex = -1;
+      const leftChildIndex = 2 * index + 1;
+      const rightChildIndex = 2 * index + 2;
+
+      if (leftChildIndex < length) {
+        if (this.heap[leftChildIndex].executeAt < element.executeAt) {
+          swapIndex = leftChildIndex;
+        }
+      }
+
+      if (rightChildIndex < length) {
+        const swapTarget = swapIndex === -1 ? element : this.heap[swapIndex];
+        if (this.heap[rightChildIndex].executeAt < swapTarget.executeAt) {
+          swapIndex = rightChildIndex;
+        }
+      }
+
+      if (swapIndex === -1) break;
+
+      this.heap[index] = this.heap[swapIndex];
+      this.heap[swapIndex] = element;
+      index = swapIndex;
+    }
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -3,10 +3,17 @@ import { AppModule } from './app.module';
 import { WinstonModule } from 'nest-winston';
 import { winstonOptions } from './common/logger/winston.config';
 
+import { SeedService } from './seed/seed.service';
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: WinstonModule.createLogger(winstonOptions),
   });
+  
+  // 개발 환경 등에서 자동 시딩 실행
+  const seedService = app.get(SeedService);
+  await seedService.seed();
+
   //도메인 발급 받으면 수정 필요.
   app.enableCors();
   await app.listen(process.env.PORT ?? 8000);

--- a/packages/backend/src/seed/seed.module.ts
+++ b/packages/backend/src/seed/seed.module.ts
@@ -1,0 +1,9 @@
+
+import { Module } from '@nestjs/common';
+import { SeedService } from './seed.service';
+
+@Module({
+  providers: [SeedService],
+  exports: [SeedService],
+})
+export class SeedModule {}

--- a/packages/backend/src/seed/seed.service.ts
+++ b/packages/backend/src/seed/seed.service.ts
@@ -1,0 +1,66 @@
+
+import { Injectable, Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Injectable()
+export class SeedService {
+  private readonly logger = new Logger(SeedService.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  async seed() {
+    this.logger.log('Starting seed process...');
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      this.logger.log('Clearing existing data...');
+      this.logger.log('Executing raw SQL seeds...');
+      
+      // SQL 파일 읽기
+      // npm run start 실행 시 CWD(현재 작업 디렉토리)가 packages/backend라고 가정
+      const seedFilePath = path.join(process.cwd(), 'db', 'seeds.sql');
+      const sql = fs.readFileSync(seedFilePath, 'utf8');
+
+      // 세미콜론(;)으로 단순 분리 시 내용에 세미콜론이 포함되어 있으면 깨질 수 있음
+      // 하지만 제공된 SQL은 문장 끝에 표준 세미콜론을 사용함
+      // 더 나은 방법: 드라이버가 허용한다면 전체 유효 SQL 블록을 실행하거나,
+      // 주의해서 분리해야 함.
+      // typeorm query runner는 연결 설정에 'multipleStatements: true'가 없으면 한 번 호출로 여러 문장을 처리하지 못할 수 있음
+      // ';/n' 등으로 분리하거나, 단순히 ';'로 분리하고 빈 문자열 필터링 시도
+      // 텍스트 내용(INSERT 값)에 세미콜론이 있을 수 있음.
+      // 하지만 사용자 텍스트 블록에는 문장 내 세미콜론이 없고 주로 구두점만 있는 것으로 보임.
+      // 완벽한 분리는 어렵지만, 여기서는 특정 문장 종결 패턴 `);`을 매칭하거나 드라이버 기능을 사용해야 함.
+      // multipleStatements가 활성화되지 않았다면 분리해야 함.
+      // 표준적인 `;\n` 또는 `;\r\n` 또는 줄 끝의 `;`로 분리 가정.
+      // 제공된 SQL은 줄 끝에 `VALUES (...);` 형태를 띰.
+      
+      const statements = sql
+        .split(/;\s*[\r\n]+/) // 세미콜론과 그 뒤의 개행 문자로 분리
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+
+      for (const statement of statements) {
+        await queryRunner.query(statement);
+      }
+
+      await queryRunner.commitTransaction();
+      this.logger.log('Seeding complete!');
+    } catch (err) {
+      this.logger.error('Seeding failed', err);
+      // rollback은 트랜잭션이 이미 커밋되었거나 깨진 경우 실패할 수 있음
+      if (queryRunner.isTransactionActive) {
+         await queryRunner.rollbackTransaction();
+      }
+      // 시작 시 "자동 실행 모드"라면 프로세스를 종료하고 싶지 않을 수 있음
+      // 하지만 검증 단계에서는 실패 여부를 알아야 함.
+      // Main.ts에서 에러를 잡고 로그를 남기며, 진행 여부를 확인함.
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}


### PR DESCRIPTION
## 🎯 이슈 번호

- close #46 

## ✅ 완료 작업 목록

- [x] **면접 생성 API 구현**: `POST /interview/tech/create` 엔드포인트 구현 (AI 면접 질문 즉시 반환)
- [x] **맞춤형 면접 컨텍스트 로드**: `documentIds`를 통해 포트폴리오 및 자기소개서 내용을 로드하고 AI 질문 생성 시 반영하도록 개선
- [x] **Document 리포지토리 분리**: `DocumentRepository`를 신설하여 문서 ID 기반의 타입 조회 및 데이터 로드 최적화
- [x] **TTL 스케줄러 구현**: 면접 세션 및 데이터 만료 관리를 위한 `MinHeapScheduler` 구현 (Min-Heap 자료구조 활용)
- [x] **KeySetStore 기능 확장**: TTL(기본 40분)이 만료되면 효율적으로 메모리를 정리하도록 스케줄러 통합

---

## 💬 리뷰어에게

면접 생성 시 사용자의 포트폴리오(`documentIds`)를 기반으로 AI가 첫 질문을 생성합니다.
또한, 메모리 관리를 위해 면접 세션 키(`documents:{id}`)에 TTL을 적용했으며, 이를 관리하기 위해 **Min-Heap 기반의 스케줄러**를 도입했습니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ Min-Heap 기반의 TTL 스케줄러 도입 배경 ]**

면접 세션 데이터가 무한정 메모리에 남는 것을 방지하기 위해 만료(TTL) 처리가 필요했습니다.

**1. `setTimeout`의 한계**
- 처음에는 각 키마다 `setTimeout`을 걸어두는 방식을 고려했습니다.
- 하지만 수천 개의 키가 등록될 경우, 수천 개의 타이머 객체가 생성되어 메모리와 이벤트 루프에 부담을 줄 수 있다고 판단했습니다.

**2. Node.js 이벤트 루프의 Timer Phase에서 착안**
- Node.js나 브라우저의 이벤트 루프가 타이머를 관리하는 방식에서 아이디어를 얻었습니다.
- **Min-Heap** 자료구조를 사용하여, **"가장 먼저 만료될 작업"**이 항상 루트(Root)에 오도록 정렬했습니다.
- 이렇게 하면 전체 리스트를 순회할 필요 없이, **O(1)**로 가장 급한 작업을 확인할 수 있고, **O(log N)**으로 새로운 작업을 추가하거나 제거할 수 있습니다.

**3. 단일 Interval로 통합 관리**
- 결과적으로 개별 타이머 대신, **단 하나의 `setInterval` (5초 주기)**만 실행합니다.
- 루프가 돌 때마다 Min-Heap의 루트를 확인(`peek`)하고, 현재 시간보다 만료 시간이 지난 작업들만 `pop`하여 제거합니다.
- 이를 통해 수많은 타이머 오버헤드를 줄이고 효율적인 스케줄링이 가능해졌습니다.

## 📸 스크린샷
<img width="1480" height="319" alt="image" src="https://github.com/user-attachments/assets/3c153329-41ca-4f7a-8dcb-36074d96b280" />
<img width="1136" height="31" alt="image" src="https://github.com/user-attachments/assets/3a396339-caf3-43cf-95f1-e9191d0e0a67" />
<img width="1134" height="47" alt="image" src="https://github.com/user-attachments/assets/c0ee9b0d-c6ae-49ac-bca9-df0af9dc6f72" />
