### PR TITLE
[Feature] 사용자는 지난 면접의 진행 시간을 조회할 수 있다.

### DIFF
--- a/packages/backend/src/interview/dto/interview-during-time-response.dto.ts
+++ b/packages/backend/src/interview/dto/interview-during-time-response.dto.ts
@@ -1,0 +1,3 @@
+export class InterviewDuringTimeResponse {
+    duringTime: number;
+}

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -17,6 +17,7 @@ import { InterviewAnswerResponse } from './dto/interview-answer-response.dto';
 import { InterviewChatHistoryResponse } from './dto/interview-chat-history-response.dto';
 import { InterviewQuestionRequest } from './dto/interview-question-request.dto';
 import { InterviewQuestionResponse } from './dto/interview-question-response.dto';
+import { InterviewDuringTimeResponse } from './dto/interview-during-time-response.dto';
 import { InterviewStopRequest } from "./dto/interview-stop-request.dto";
 
 import { CreateInterviewRequestDto } from './dto/create-interview-request.dto';
@@ -100,5 +101,14 @@ export class InterviewController {
     @Body() body: InterviewQuestionRequest,
   ): Promise<InterviewQuestionResponse> {
     return await this.interviewService.chatInterviewer(body.interviewId);
+  }
+
+  @Get(':interviewId/time')
+  async getEndTime(
+    @Param('interviewId') interviewId: string,
+  ): Promise<InterviewDuringTimeResponse> {
+    // 인증이 없기 때문에 userId를 상수화
+    const userId = '1';
+    return await this.interviewService.getDuringTime(userId, interviewId);
   }
 }

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -14,6 +14,7 @@ import { SttService } from './stt.service';
 import { InterviewRepository } from './interview.repository';
 import { Interview } from './entities/interview.entity';
 import { InterviewChatHistoryResponse } from './dto/interview-chat-history-response.dto';
+import { InterviewDuringTimeResponse } from './dto/interview-during-time-response.dto';
 import { PortfolioRepository } from '../document/repositories/portfolio.repository';
 import { CoverLetterRepository } from '../document/repositories/cover-letter.repository';
 import { CreateInterviewResponseDto } from './dto/create-interview-response.dto';
@@ -50,6 +51,22 @@ export class InterviewService {
     interview.calculateDuringTime(endTime);
 
     await this.interviewRepository.save(interview);
+  }
+
+  async getDuringTime(
+    userId: string,
+    interviewId: string,
+  ): Promise<InterviewDuringTimeResponse> {
+    const interview = await this.findExistingInterview(interviewId, ['user']);
+    interview.validateUser(userId);
+
+    if (!interview.duringTime) {
+      throw new NotFoundException('인터뷰가 아직 종료되지 않았습니다.');
+    }
+
+    return {
+      duringTime: interview.duringTime
+    };
   }
 
   async createTechInterview(


### PR DESCRIPTION
## 🎯 이슈 번호

- close #51

## ✅ 완료 작업 목록

- [x] 면접 진행 시간 조회 API (`GET /interview/:interviewId/time`) 구현
- [x] `InterviewDuringTimeResponse` DTO 추가
- [x] 종료되지 않은 면접 조회 시 예외 처리 로직 구현

---

## 💬 리뷰어에게

- 면접 결과 페이지 등에서 면접 진행 시간을 확인하기 위한 API입니다.
- `InterviewService.getDuringTime` 메서드에서 면접이 종료되지 않아 `duringTime`이 없는 경우 `NotFoundException`을 발생시키도록 처리했습니다.
- number 타입으로 진행 시간을 반환합니다. 프론트에서 날짜 타입으로 변형하여 사용하면 됩니다.

---