### PR TITLE
[Feature] 음성으로 답변하기 검증로직 추가

### DIFF
--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -1,7 +1,9 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
+  Logger,
   Param,
   Post,
   UploadedFile,
@@ -24,6 +26,7 @@ import { CreateInterviewResponseDto } from './dto/create-interview-response.dto'
 
 @Controller('interview')
 export class InterviewController {
+  private readonly logger = new Logger(InterviewController.name);
   constructor(private readonly interviewService: InterviewService) { }
 
   @Post('tech/create')
@@ -41,6 +44,13 @@ export class InterviewController {
     @UploadedFile() file: Express.Multer.File,
     @Body() body: InterviewAnswerVoiceRequest,
   ): Promise<InterviewAnswerResponse> {
+    if (!file) {
+      this.logger.warn(
+          `answer/voice 요청에 음성 파일이 누락 되었습니다. - interviewId=${body.interviewId}`,
+      );
+      throw new BadRequestException('음성 파일이 없습니다.');
+    }
+
     // 인증이 없기 때문에 userId를 상수화
     const userId = '1';
     const answerResult = await this.interviewService.answerWithVoice(

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -109,6 +110,13 @@ export class InterviewService {
     ]);
     interview.validateUser(userId);
     const sttResult = await this.sttService.transform(file);
+
+    if (!sttResult) {
+      this.logger.warn(
+          `음성 파일을 STT 변환 했지만 빈 텍스트입니다. interviewId=${interviewId}`,
+      );
+      throw new BadRequestException('음성 파일 내용이 비어있습니다.');
+    }
 
     // interview의 cascade를 활용해 answer 엔티티를 삽입한다.
     const answer = new InterviewAnswer(sttResult);


### PR DESCRIPTION
## 🎯 이슈 번호

- close #52

## ✅ 완료 작업 목록

- [x] 음성 답변 API (`POST /interview/answer/voice`) 요청 시 파일 누락 검증 추가
- [x] STT 변환 결과가 비어있는 경우에 대한 예외 처리 추가

---

## 💬 리뷰어에게

- `InterviewController`에서 파일이 `undefined`인 경우 `BadRequestException`을 발생시키도록 했습니다.
- `InterviewService`에서 STT 변환 결과가 빈 문자열일 경우 `BadRequestException`을 발생시키도록 처리를 추가했습니다. 이를 통해 불완전한 데이터가 DB에 저장되는 것을 방지합니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 빈 STT 결과에 대한 처리 ]**

- **문제점**: 사용자가 말을 하지 않거나 잡음만 녹음되어 STT API가 빈 문자열을 반환하는 경우, 이를 그대로 답변으로 저장해야 할지 고민했습니다.
- **해결 과정**: 답변 내용이 없는 것은 유효한 면접 진행이 아니라고 판단하여 `BadRequestException`을 발생시켜 클라이언트에게 다시 요청하도록 유도하는 것이 적절하다고 보았습니다.