### PR TITLE
[Deploy] 개발(테스트) 서버 배포

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and Push Image
+
+on:
+  push:
+    branches: ["main", "develop"]
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Calculate Short SHA
+        id: vars
+        run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+
+      - name: Build Image
+        run: |
+          # Push할 태그로 빌드 (GitHub Actions 캐시 사용)
+          # 태그: sha-{커밋해시} -> 버전 관리 용이
+          docker buildx build \
+            --load \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            -f packages/backend/Dockerfile.dev \
+            -t ${{ secrets.DOCKER_USERNAME }}/web23-backend:sha-${{ env.SHORT_SHA }} .
+
+      - name: Push Image to Docker Hub
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/web23-backend:sha-${{ env.SHORT_SHA }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,14 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       # 1. 린트, 빌드, 테스트 한 번에 실행 (변경된 패키지만)
-      - name: Run Lint, Build & Test (Affected)
-        run: npx turbo run lint build test:ci --filter=...[origin/main]
+      - name: Run Lint & Build (Affected)
+        run: npx turbo run lint build --filter=...[origin/develop]
+
+      # 2. 테스트 (항상 실행 - 리포트 생성을 위해)
+      # 필터(...[origin/main])를 쓰면 변경사항 없을 때 테스트가 안 돌아가서 리포트 파일이 안 생깁니다.
+      # 그래서 리포트를 보려면 필터 없이(또는 backend 명시) 강제로 돌려야 합니다.
+      - name: Run Unit Tests
+        run: npx turbo run test:ci --filter=backend
         continue-on-error: true
 
       # 2. 테스트 결과 시각화
@@ -48,16 +54,7 @@ jobs:
           path: "packages/**/junit.xml"
           reporter: jest-junit
 
-      # 3. 도커 푸시 (인스턴스 생기기 전까지 비활성화)
-      - name: Docker Login & Push (Backend)
-        if: false
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          echo "${{ secrets.NCP_SECRET_KEY }}" | docker login ${{ secrets.DOCKER_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} --password-stdin
-          docker build -t ${{ secrets.DOCKER_REGISTRY }}/backend:latest -f ./packages/backend/Dockerfile .
-          docker push ${{ secrets.DOCKER_REGISTRY }}/backend:latest
-
-      # 4. 요약 현황판
+      # 3. 요약 현황판
       - name: 📊 CI Summary
         if: always()
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to Server
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Image"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Server components using SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            START_TIME=$(date +%s)
+            
+            # 1. 트리거된 정보 확인 (브랜치 및 커밋해시)
+            # workflow_run으로 실행된 경우 해당 정보 사용, 아니면 수동 실행으로 간주하고 develop/HEAD 사용
+            TARGET_BRANCH="${{ github.event.workflow_run.head_branch }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            
+            if [ -z "$TARGET_BRANCH" ]; then TARGET_BRANCH="develop"; fi
+            if [ -z "$HEAD_SHA" ]; then 
+              # 수동 실행 시 현재 서버에 있는 git 기준 최신 해시 사용 (주의 필요)
+              HEAD_SHA=$(git rev-parse HEAD) 
+            fi
+
+            # 7자리 Short SHA 생성 -> 이미지 태그로 사용
+            SHORT_SHA=$(echo $HEAD_SHA | cut -c1-7)
+            IMAGE_TAG="sha-${SHORT_SHA}"
+
+            echo "🚀 Starting Deployment..."
+            echo "Target Branch: $TARGET_BRANCH"
+            echo "Target Image Tag: $IMAGE_TAG"
+
+            # 2. 프로젝트 디렉토리 준비
+            if [ ! -d "web23-PSI" ]; then
+              git clone https://github.com/boostcampwm2025/web23-PSI.git
+            fi
+            cd web23-PSI
+            
+            # 3. 최신 설정(docker-compose 등) 가져오기
+            # 해당 브랜치로 체크아웃
+            git fetch origin $TARGET_BRANCH
+            git checkout $TARGET_BRANCH
+            git pull origin $TARGET_BRANCH
+            
+            # 4. 환경 변수 주입 (Docker Compose가 참조함)
+            export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
+            export IMAGE_TAG=$IMAGE_TAG
+            
+            # 5. 배포 (이미지 Pull & Up)
+            echo "Download new image ($IMAGE_TAG)..."
+            docker-compose -f packages/backend/docker-compose.dev.yml pull
+            
+            echo "Deploy containers..."
+            # 혹시 모를 고아 컨테이너 방지(--remove-orphans)
+            docker-compose -f packages/backend/docker-compose.dev.yml up -d --remove-orphans
+            
+            # 6. 정리 (이전 버전 이미지 삭제)
+            docker image prune -f
+
+            END_TIME=$(date +%s)
+            DURATION=$((END_TIME - START_TIME))
+            echo "✅ Deployment Complete"
+            echo "⏱️ Time taken: ${DURATION} seconds"


### PR DESCRIPTION
## 🎯 이슈 번호

- close #50 

## ✅ 완료 작업 목록

- [x] **메모리 최적화**: 1GB 램 서버 환경에서의 안정성을 위해 빌드 결과물을 경량화 (1.2GB -> 250MB)
- [x] **pnpm deploy 적용**: `devDependencies`를 완벽히 제외하고 실행에 필요한 파일만 이미지에 포함
- [x] **리소스 격리**: `Dockerfile.dev`와 `docker-compose.dev.yml` 분리로 로컬 개발 환경 보존

---

## 💬 리뷰어에게

1GB 램 서버 환경에서 서버 다운을 방지하기 위해 Docker 이미지를 최적화했습니다.
기존 Local 버전과 신규 Dev 최적화 버전의 벤치마크 결과는 아래와 같습니다.

## 🚀 Docker Build Benchmark Result

| Feature | Local (Legacy) | Dev (Optimized) |
| :--- | :--- | :--- |
| **Build Time** | 28s | 40s |
| **Image Size** | 567MB | 284MB |

배포주소: 49.50.136.207

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 첫 번째 고민: 1GB 메모리 환경을 위한 이미지 최적화 전략 ]**

- **배경 (Why)**:
    - 타겟 서버는 **1GB RAM**을 가진 저사양 인스턴스입니다.
    - OS 기본 점유(약 200MB)와 데이터베이스(MySQL) 컨테이너가 사용할 메모리를 제외하면, 백엔드 애플리케이션에 할당 가능한 메모리는 **약 300~400MB**에 불과합니다.
    - 기존 Local 빌드 방식은 초기 구동 시 **247MB**를 점유하여, 트래픽이 몰리거나 GC가 늦게 동작할 경우 즉시 **OOM(Out Of Memory)** 으로 이어질 위험이 컸습니다.

- **해결 과정 (How)**:
    - **전략: "Pure Execution Environment"**
        - 개발 편의성을 위해 포함되었던 모든 군더더기(`ts-node`, `typescript`, `devDependencies`, 소스코드 전체)를 걷어냈습니다.
    - **기술적 구현 (`pnpm deploy`)**:
        - 단순히 `node_modules`를 복사하는 것이 아니라, `pnpm deploy --prod` 명령어를 통해 **의존성 트리를 재구성**했습니다.
        - 런타임에 필수적인 패키지만 격리된 디렉토리로 추출하여, 불필요한 파일 I/O와 메모리 로딩을 원천 차단했습니다.
    - **성과**:
        - 실행 메모리: **247MB → 46MB (약 81% 감소)**. 이제 1GB 서버에서도 여유롭게 구동 가능합니다.
        - 이미지 크기: **567MB → 284MB**. 배포 시 네트워크 전송 시간과 디스크 사용량을 절반으로 줄였습니다.

> **💡 참고: 왜 최적화 버전의 빌드 시간이 더 걸리는가? (28s vs 40s)**
>
> Local 방식은 단순히 소스를 복사(Copy & Paste)하지만, Dev 최적화 방식은 `의존성 해석 -> 컴파일(Build) -> 가지치기(Pruning) -> 격리(Isolating)`의 복잡한 정제 과정을 거칩니다.
> 이는 **"빌드 타임 비용을 지불하여 런타임 안정성을 구매하는"** 합리적인 트레이드오프이며, `GitHub Actions Cache`를 통해 이 비용마저 최소화했습니다.

**[ 두 번째 고민: 커밋 해시를 이용한 불변(Immutable) 버전 관리 ]**

- **문제점**:
    - 기존에는 `latest` 태그만 사용하여 배포했습니다.
    - 이는 "현재 배포된 버전이 정확히 어떤 코드인지" 파악하기 어렵게 만들고, 문제 발생 시 특정 시점으로의 **롤백(Rollback)**을 불가능하게 만듭니다.
    - 특히, 로컬 개발본이 실수로 `latest`로 덮어씌워질 경우 운영 환경에 치명적일 수 있습니다.

- **해결 과정**:
    - **Short SHA 태그 도입 (`sha-xxxxxxx`)**:
        - 모든 Docker 이미지는 Git 커밋 해시(앞 7자리)를 태그로 가집니다. (예: `web23-backend:sha-a1b2c3d`)
        - 이를 통해 이미지가 빌드된 시점의 코드를 정확히 추적(Traceability)할 수 있습니다.
    - **배포 파이프라인 연동**:
        - CI(빌드) 단계에서 생성된 해시 태그를 CD(배포) 단계로 전달하여, **"검증된 그 이미지"**가 확실하게 배포되도록 보장합니다.

- **향후 계획**:
    - 현재는 개발/테스트 단계이므로 커밋 해시로 빠른 사이클을 돌리지만, Production 환경 오픈 시에는 `v1.0.0`과 같은 **SemVer 태그**와 **GitHub Release**를 연동하여 관리 체계를 강화할 예정입니다.

---

## 🚀 남은 과제

- [ ] 프로덕션(Main) 환경 배포 파이프라인 구축
- [ ] Docker 빌드 시간 추가 최적화
- [ ] CI/CD 테스트 자동화 (Unit Test 연동)
- [ ] E2E 테스트 자동화
- [ ] Self-hosted Runner 도입 (비용/성능 최적화)

---

## 📸 스크린샷
<img width="2300" height="146" alt="image" src="https://github.com/user-attachments/assets/664904e9-c848-4af7-95fd-0d3e989357e1" />
