### PR TITLE
[Feature] 사용자는 지난 면접 피드백을 조회할 수 있다.

### DIFF
--- a/packages/backend/src/interview/dto/interview-feedback-response.dto.ts
+++ b/packages/backend/src/interview/dto/interview-feedback-response.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from "class-validator";
+
+export class InterviewFeedbackResponse {
+    @IsNumber()
+    score: string;
+
+    @IsString()
+    feedback: string;
+}

--- a/packages/backend/src/interview/entities/interview.entity.ts
+++ b/packages/backend/src/interview/entities/interview.entity.ts
@@ -51,6 +51,12 @@ export class Interview {
   @Column({ name: 'during_time', type: 'bigint', nullable: true })
   duringTime: number;
 
+  @Column({ name: 'score', type: 'varchar', length: 10, nullable: true })
+  score: string;
+
+  @Column({ name: 'feedback', type: 'varchar', length: 1000, nullable: true })
+  feedback: string;
+
   @ManyToOne(() => User, (user) => user.interviews)
   @JoinColumn({ name: 'user_id' })
   user: User;

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -101,4 +101,25 @@ export class InterviewController {
   ): Promise<InterviewQuestionResponse> {
     return await this.interviewService.chatInterviewer(body.interviewId);
   }
+
+  @Post('/feedback')
+  async generateAiInterview(
+    @Body() body: CreateFeedbackRequest,
+  ): Promise<InterviewFeedbackResponse> {
+    const userId = '1';
+    return await this.interviewService.createInterviewFeedback(
+      userId,
+      body.interviewId
+    );
+  }
+
+  @Get('/:interviewId/feedback')
+  async getInterviewFeedback(
+    @Param('interviewId') interviewId: string
+  ): Promise<InterviewFeedbackResponse> {
+    // 인증이 없기 때문에 userId를 상수화
+    const userId = '1';
+    return this.interviewService.findInterviewFeedback(userId, interviewId);
+  }
+
 }

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -164,6 +164,25 @@ export class InterviewService {
     );
   }
 
+  async createInterviewFeedback(userId: string, interviewId: string): Promise<InterviewFeedbackResponse> {
+    const interview = await this.findExistingInterview(interviewId, [
+      'answers',
+      'user',
+      'questions',
+    ]);
+    interview.validateUser(interview.user.userId);
+
+    const feedbackDto = await this.interviewFeedBackService.requestTechInterviewFeedBack(
+      interview.questions,
+      interview.answers,
+    );
+
+    interview.feedback = feedbackDto.feedback;
+    interview.score = feedbackDto.score;
+    await this.interviewRepository.save(interview);
+    return feedbackDto;
+  }
+
   async chatInterviewer(interviewId: string) {
     const questions: InterviewQuestion[] =
       await this.questionRepository.findFiveByInterviewId(interviewId);
@@ -235,5 +254,19 @@ export class InterviewService {
     }
 
     throw new InternalServerErrorException('Failed to parse JSON response');
+  }
+
+  async findInterviewFeedback(
+    userId: string,
+    interviewId: string,
+  ): Promise<InterviewFeedbackResponse> {
+    const interview = await this.findExistingInterview(interviewId, [
+      'user',
+    ]);
+    interview.validateUser(userId);
+    return {
+      score: interview.score,
+      feedback: interview.feedback,
+    };
   }
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #62

## ✅ 완료 작업 목록

- [x] 면접 피드백 조회 API 구현 (GET /interview/:interviewId/feedback)
---

## 💬 리뷰어에게


- 이전에 면접 피드백 생성하기 PR에선 interview 엔티티에 score 프로퍼티가 없었습니다. 정상적인 면접 피드백 조회를 위해 score 프로퍼티를 추가하고 데이터 베이스 영속 작업도 진행했습니다.
---
