### PR TITLE
[UI] 인터뷰 준비 페이지 레이아웃 개선 및 미디어 권한 처리 개선

### DIFF
--- a/packages/frontend/app/(tabs)/(simulator)/components/document-card.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/components/document-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Calendar, Check } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence } from "motion/react";
 import { Card, CardContent } from "@/app/components/ui/card";
 import { cn } from "@/app/lib/utils";
 

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/components/video-status.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/components/video-status.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMediaPermissions } from "@/app/hooks/use-media-permissions";
-import { Aperture, CircleCheck } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { Aperture, CircleAlert, CircleCheck } from "lucide-react";
+
+import { useMediaPermissions } from "@/app/hooks/use-media-permissions";
 
 export default function VideoStatus() {
   const {
@@ -33,16 +34,14 @@ export default function VideoStatus() {
 
   return (
     <div>
-      <div className="relative overflow-hidden rounded-3xl">
+      <div className="relative aspect-video overflow-hidden rounded-3xl bg-primary/20">
         <div className="absolute top-5 left-5 flex items-center gap-2 rounded-2xl border bg-white/30 px-3 py-1 backdrop-blur-md">
           <Aperture className="size-3" />
           <span className="text-sm font-semibold uppercase">
             preview activate
           </span>
         </div>
-        <div className="video flex justify-center bg-primary/20">
-          <video ref={videoRef} autoPlay muted />
-        </div>
+        <video ref={videoRef} autoPlay muted />
       </div>
       <div className="mt-4 grid grid-cols-2 gap-3">
         <div className="flex justify-between rounded-xl border p-4">
@@ -50,11 +49,11 @@ export default function VideoStatus() {
             camera
           </p>
           {!hasVideoPermission ? (
-            <span className="text-sm font-semibold text-red-500">off</span>
+            <CircleAlert className="size-5 text-red-500" />
           ) : isVideoEnabled ? (
             <CircleCheck className="size-5 text-primary" />
           ) : (
-            <span className="text-sm font-semibold text-red-500">off</span>
+            <CircleAlert className="size-5 text-red-500" />
           )}
         </div>
         <div className="flex justify-between rounded-xl border p-4">
@@ -62,11 +61,11 @@ export default function VideoStatus() {
             mic
           </p>
           {!hasAudioPermission ? (
-            <span className="text-sm font-semibold text-red-500">off</span>
+            <CircleAlert className="size-5 text-red-500" />
           ) : isAudioEnabled ? (
             <CircleCheck className="size-5 text-primary" />
           ) : (
-            <span className="text-sm font-semibold text-red-500">off</span>
+            <CircleAlert className="size-5 text-red-500" />
           )}
         </div>
       </div>

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/components/video-status.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/components/video-status.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMediaPermissions } from "@/app/hooks/use-media-permissions";
+import { Aperture, CircleCheck } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+export default function VideoStatus() {
+  const {
+    requestVideo,
+    requestAudio,
+    videoStream,
+    audioStream,
+    hasAudioPermission,
+    isAudioEnabled,
+    hasVideoPermission,
+    isVideoEnabled,
+  } = useMediaPermissions();
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (requestAudio && requestVideo && !videoStream && !audioStream) {
+      requestVideo();
+      requestAudio();
+    }
+  }, [requestAudio, requestVideo, videoStream, audioStream]);
+
+  useEffect(() => {
+    if (videoRef.current && videoStream) {
+      videoRef.current.srcObject = videoStream;
+    }
+  }, [videoStream]);
+
+  return (
+    <div>
+      <div className="relative overflow-hidden rounded-3xl">
+        <div className="absolute top-5 left-5 flex items-center gap-2 rounded-2xl border bg-white/30 px-3 py-1 backdrop-blur-md">
+          <Aperture className="size-3" />
+          <span className="text-sm font-semibold uppercase">
+            preview activate
+          </span>
+        </div>
+        <div className="video flex justify-center bg-primary/20">
+          <video ref={videoRef} autoPlay muted />
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="flex justify-between rounded-xl border p-4">
+          <p className="text-sm font-semibold text-muted-foreground uppercase">
+            camera
+          </p>
+          {!hasVideoPermission ? (
+            <span className="text-sm font-semibold text-red-500">off</span>
+          ) : isVideoEnabled ? (
+            <CircleCheck className="size-5 text-primary" />
+          ) : (
+            <span className="text-sm font-semibold text-red-500">off</span>
+          )}
+        </div>
+        <div className="flex justify-between rounded-xl border p-4">
+          <p className="text-sm font-semibold text-muted-foreground uppercase">
+            mic
+          </p>
+          {!hasAudioPermission ? (
+            <span className="text-sm font-semibold text-red-500">off</span>
+          ) : isAudioEnabled ? (
+            <CircleCheck className="size-5 text-primary" />
+          ) : (
+            <span className="text-sm font-semibold text-red-500">off</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/page.tsx
@@ -5,47 +5,15 @@ import { ArrowRight, ShieldCheck, Sparkles } from "lucide-react";
 import { Button } from "@/app/components/ui/button";
 import { getHistory } from "./actions";
 import VideoStatus from "./components/video-status";
+import Link from "next/link";
+import InterviewClient from "./client";
 
 export default async function Page() {
   const { history } = await getHistory({ interviewId: "1" });
 
   return (
-    <div className="flex max-w-360 gap-8">
-      {/* <InterviewClient history={history} /> */}
-      <div className="flex-1">
-        <VideoStatus />
-      </div>
-      <div className="flex-1">
-        <div className="flex w-fit items-center gap-2 rounded-sm bg-primary/20 px-2 py-1">
-          <Sparkles className="size-3 text-primary" />
-          <h5 className="text-xs font-semibold text-primary"> 준비 완료</h5>
-        </div>
-        <div className="mt-4 flex flex-col gap-1 text-4xl font-bold text-pretty">
-          <h3>준호 님,</h3>
-          <h3>준비되셨나요?</h3>
-        </div>
-        <span className="mt-4 block text-base font-semibold text-muted-foreground">
-          선택하신 정보를 바탕으로 직무 시뮬레이션이 준비되었습니다. 실제 면접과
-          유사한 답변을 연습해보세요.
-        </span>
-
-        <div className="mt-8 flex gap-3 rounded-lg border px-4 py-6 shadow-sm">
-          <div className="flex size-10 items-center justify-center rounded-md bg-primary/10">
-            <ShieldCheck className="size-5 text-primary" />
-          </div>
-          <div>
-            <h3 className="text-sm font-semibold">개인정보 및 보안 안내</h3>
-            <span className="text-xs text-muted-foreground">
-              세션 중 찰영되는 영상과 음성은 분석을 위해서만 사용되며, 종료 후
-              안전하게 삭제됩니다.
-            </span>
-          </div>
-        </div>
-        <Button className="mt-4 w-full py-7 font-semibold">
-          <p>면접 시작하기 </p>
-          <ArrowRight />
-        </Button>
-      </div>
+    <div className="mx-auto mt-8 flex max-w-360">
+      <InterviewClient history={history} />
     </div>
   );
 }

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/page.tsx
@@ -1,14 +1,51 @@
 "use server";
 
+import { ArrowRight, ShieldCheck, Sparkles } from "lucide-react";
+
+import { Button } from "@/app/components/ui/button";
 import { getHistory } from "./actions";
-import InterviewClient from "./client";
+import VideoStatus from "./components/video-status";
 
 export default async function Page() {
   const { history } = await getHistory({ interviewId: "1" });
 
   return (
-    <div>
-      <InterviewClient history={history} />
+    <div className="flex max-w-360 gap-8">
+      {/* <InterviewClient history={history} /> */}
+      <div className="flex-1">
+        <VideoStatus />
+      </div>
+      <div className="flex-1">
+        <div className="flex w-fit items-center gap-2 rounded-sm bg-primary/20 px-2 py-1">
+          <Sparkles className="size-3 text-primary" />
+          <h5 className="text-xs font-semibold text-primary"> 준비 완료</h5>
+        </div>
+        <div className="mt-4 flex flex-col gap-1 text-4xl font-bold text-pretty">
+          <h3>준호 님,</h3>
+          <h3>준비되셨나요?</h3>
+        </div>
+        <span className="mt-4 block text-base font-semibold text-muted-foreground">
+          선택하신 정보를 바탕으로 직무 시뮬레이션이 준비되었습니다. 실제 면접과
+          유사한 답변을 연습해보세요.
+        </span>
+
+        <div className="mt-8 flex gap-3 rounded-lg border px-4 py-6 shadow-sm">
+          <div className="flex size-10 items-center justify-center rounded-md bg-primary/10">
+            <ShieldCheck className="size-5 text-primary" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold">개인정보 및 보안 안내</h3>
+            <span className="text-xs text-muted-foreground">
+              세션 중 찰영되는 영상과 음성은 분석을 위해서만 사용되며, 종료 후
+              안전하게 삭제됩니다.
+            </span>
+          </div>
+        </div>
+        <Button className="mt-4 w-full py-7 font-semibold">
+          <p>면접 시작하기 </p>
+          <ArrowRight />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/ready/layout.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/ready/layout.tsx
@@ -1,0 +1,11 @@
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-5 flex size-full items-start lg:mt-0 lg:items-center">
+      {children}
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/ready/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/ready/page.tsx
@@ -1,0 +1,50 @@
+import { ArrowRight, ShieldCheck, Sparkles } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/app/components/ui/button";
+
+import VideoStatus from "../components/video-status";
+
+export default async function InterviewReadyPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-360 flex-col gap-8 lg:flex-row">
+      {/* <InterviewClient history={history} /> */}
+      <div className="flex-1">
+        <VideoStatus />
+      </div>
+      <div className="flex-1">
+        <div className="flex w-fit items-center gap-2 rounded-sm bg-primary/20 px-2 py-1">
+          <Sparkles className="size-3 text-primary" />
+          <h5 className="text-xs font-semibold text-primary"> 준비 완료</h5>
+        </div>
+        <div className="mt-4 flex flex-col gap-1 text-4xl font-bold text-pretty">
+          <h3>준호 님,</h3>
+          <h3>준비되셨나요?</h3>
+        </div>
+        <span className="mt-4 block text-base font-semibold text-muted-foreground">
+          선택하신 정보를 바탕으로 직무 시뮬레이션이 준비되었습니다. 실제 면접과
+          유사한 답변을 연습해보세요.
+        </span>
+
+        <div className="mt-8 flex gap-3 rounded-lg border px-4 py-6 shadow-sm">
+          <div className="flex size-10 items-center justify-center rounded-md bg-primary/10">
+            <ShieldCheck className="size-5 text-primary" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold">개인정보 및 보안 안내</h3>
+            <span className="text-xs text-muted-foreground">
+              세션 중 찰영되는 영상과 음성은 분석을 위해서만 사용되며, 종료 후
+              안전하게 삭제됩니다.
+            </span>
+          </div>
+        </div>
+        <Link href={`./`}>
+          <Button className="mt-4 w-full cursor-pointer py-7 font-semibold">
+            <p>면접 시작하기 </p>
+            <ArrowRight />
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/components/interview-controls.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/components/interview-controls.tsx
@@ -10,9 +10,8 @@ interface InterviewControlsProps {
   setIsCamOn: (val: boolean) => void;
   isMicOn: boolean;
   setIsMicOn: (val: boolean) => void;
-  pauseVideo: () => void;
-  resumeVideo: () => void;
-  toggleMic: (enabled: boolean) => void;
+  toggleVideo: (enabled: boolean) => void;
+  toggleAudio: (enabled: boolean) => void;
   onExit: () => void;
 }
 
@@ -22,29 +21,22 @@ export function InterviewControls({
   setIsCamOn,
   isMicOn,
   setIsMicOn,
-  pauseVideo,
-  resumeVideo,
-  toggleMic,
+  toggleVideo,
+  toggleAudio,
   onExit,
 }: InterviewControlsProps) {
   // 마이크 토글 (녹화 중 음소거/활성화)
   const handleMicToggle = () => {
     const newMicState = !isMicOn;
     setIsMicOn(newMicState);
-    toggleMic(newMicState);
+    toggleAudio(newMicState);
   };
 
   // 카메라 토글 (트랙만 끄고 켜기)
   const handleCamToggle = async () => {
-    if (isCamOn) {
-      // 카메라만 일시 중지
-      pauseVideo();
-      setIsCamOn(false);
-    } else {
-      // 카메라 재개
-      resumeVideo();
-      setIsCamOn(true);
-    }
+    const newCamState = !isCamOn;
+    setIsCamOn(newCamState);
+    toggleVideo(newCamState);
   };
 
   return (

--- a/packages/frontend/app/(tabs)/(simulator)/interview/create/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/create/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, Plus } from "lucide-react";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
 import { cn } from "@/app/lib/utils";

--- a/packages/frontend/app/(tabs)/(simulator)/layout.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/layout.tsx
@@ -2,9 +2,9 @@ import Header from "@/app/components/header";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
+    <div className="flex h-dvh flex-col">
       <Header />
-      <div className="size-full h-full px-6">{children}</div>
+      <div className="flex-1 px-6">{children}</div>
     </div>
   );
 }

--- a/packages/frontend/app/api/interview/[id]/history/route.ts
+++ b/packages/frontend/app/api/interview/[id]/history/route.ts
@@ -1,7 +1,7 @@
 import { getHistory } from "@/app/(tabs)/(simulator)/interview/[id]/actions";
 import { NextResponse } from "next/server";
 
-export async function GET(req: Request) {
+export async function GET() {
   const history = await getHistory({ interviewId: "1" });
   return NextResponse.json(history);
 }

--- a/packages/frontend/app/hooks/use-media-permissions.ts
+++ b/packages/frontend/app/hooks/use-media-permissions.ts
@@ -1,73 +1,174 @@
-/**
- * 카메라/마이크 권한 요청 및 미디어 스트림의 생명주기(생성/해제)를 관리하는 커스텀 훅
- */
-
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 export const useMediaPermissions = () => {
-  const [stream, setStream] = useState<MediaStream | null>(null);
+  // 비디오와 오디오 스트림을 완전히 분리하여 관리
+  const [videoStream, setVideoStream] = useState<MediaStream | null>(null);
+  const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
 
-  const requestPermissions = useCallback(
-    async (options?: { video?: boolean; audio?: boolean }) => {
+  const [videoDeviceId, setVideoDeviceId] = useState<string | null>(null);
+  const [audioDeviceId, setAudioDeviceId] = useState<string | null>(null);
+
+  const [isVideoEnabled, setIsVideoEnabled] = useState<boolean>(false);
+  const [isAudioEnabled, setIsAudioEnabled] = useState<boolean>(false);
+
+  const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([]);
+  const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
+  const [mediaError, setMediaError] = useState<Error | null>(null);
+
+  /** 장치 목록 가져오기 */
+  const getMediaDevices = useCallback(async () => {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      setVideoDevices(
+        devices.filter((devices) => devices.kind === "videoinput"),
+      );
+      setAudioDevices(
+        devices.filter((devices) => devices.kind === "audioinput"),
+      );
+    } catch (error) {
+      setMediaError(error as Error);
+    }
+  }, []);
+
+  /** 비디오 권한 및 스트림 요청 */
+  const requestVideo = useCallback(
+    async (deviceId?: string) => {
       try {
-        const {video = true , audio = true} = options || {};
-        const mediaStream = await navigator.mediaDevices.getUserMedia({
-          video: video,
-          audio: audio,
+        if (videoStream) {
+          videoStream.getTracks().forEach((track) => track.stop());
+        }
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: deviceId ? { deviceId: { exact: deviceId } } : true,
         });
-        setStream(mediaStream);
-        return mediaStream;
+        setVideoStream(stream);
+        const track = stream.getVideoTracks()[0];
+        setVideoDeviceId(track.getSettings().deviceId || null);
+        setIsVideoEnabled(track.enabled);
+        await getMediaDevices();
+        return stream;
       } catch (error) {
-        console.error("Error accessing media devices.", error);
-        return error;
+        setMediaError(error as Error);
+        return null;
       }
     },
-    [],
+    [videoStream, getMediaDevices],
   );
 
-  const stopMediaStream = useCallback(() => {
-    if (stream) {
-      stream.getTracks().forEach((track) => track.stop());
-      setStream(null);
-    }
-  }, [stream]);
+  /** 오디오 권한 및 스트림 요청 */
+  const requestAudio = useCallback(
+    async (deviceId?: string) => {
+      try {
+        if (audioStream) {
+          audioStream.getTracks().forEach((track) => track.stop());
+        }
 
-  // 카메라 트랙 비활성화
-  const pauseVideoRecording = useCallback(() => {
-    if (stream) {
-      stream.getVideoTracks().forEach((track) => {
-        track.enabled = false;
-      });
-    }
-  }, [stream]);
-
-  // 카메라 트랙 활성화
-  const resumeVideoRecording = useCallback(() => {
-    if (stream) {
-      stream.getVideoTracks().forEach((track) => {
-        track.enabled = true;
-      });
-    }
-  }, [stream]);
-
-  // 마이크 트랙 음소거/활성화
-  const toggleMicTrack = useCallback(
-    (enabled: boolean) => {
-      if (stream) {
-        stream.getAudioTracks().forEach((track) => {
-          track.enabled = enabled;
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
         });
+
+        setAudioStream(stream);
+
+        const track = stream.getAudioTracks()[0];
+        setAudioDeviceId(track.getSettings().deviceId || null);
+        setIsAudioEnabled(track.enabled);
+
+        await getMediaDevices();
+
+        return stream;
+      } catch (error) {
+        setMediaError(error as Error);
+        return null;
       }
     },
-    [stream],
+    [audioStream, getMediaDevices],
+  );
+
+  /**  통합 권한 요청 (초기 설정용) */
+  const requestPermissions = useCallback(
+    async (options?: { video?: boolean; audio?: boolean }) => {
+      const { video = true, audio = true } = options || {};
+
+      let videoStream = null;
+      let audioStream = null;
+
+      if (video) {
+        videoStream = await requestVideo();
+      }
+
+      if (audio) {
+        audioStream = await requestAudio();
+      }
+
+      return { videoStream, audioStream };
+    },
+    [requestVideo, requestAudio],
+  );
+
+  /** 스트림 종료 (전체 또는 개별) */
+  const stopMediaStream = useCallback(() => {
+    videoStream?.getTracks().forEach((track) => track.stop());
+    audioStream?.getTracks().forEach((track) => track.stop());
+    setVideoStream(null);
+    setAudioStream(null);
+    setIsVideoEnabled(false);
+    setIsAudioEnabled(false);
+  }, [videoStream, audioStream]);
+
+  // 트랙 상태 감시 (시스템에 의한 종료 대응)
+  useEffect(() => {
+    const handleVideoEnded = () => setIsVideoEnabled(false);
+    const handleAudioEnded = () => setIsAudioEnabled(false);
+
+    const videoTrack = videoStream?.getVideoTracks()[0];
+    const audioTrack = audioStream?.getAudioTracks()[0];
+
+    videoTrack?.addEventListener("ended", handleVideoEnded);
+    audioTrack?.addEventListener("ended", handleAudioEnded);
+
+    return () => {
+      videoTrack?.removeEventListener("ended", handleVideoEnded);
+      audioTrack?.removeEventListener("ended", handleAudioEnded);
+    };
+  }, [videoStream, audioStream]);
+
+  const toggleVideo = useCallback(
+    (enabled: boolean) => {
+      videoStream
+        ?.getVideoTracks()
+        .forEach((track) => (track.enabled = enabled));
+      setIsVideoEnabled(enabled);
+    },
+    [videoStream],
+  );
+
+  const toggleAudio = useCallback(
+    (enabled: boolean) => {
+      audioStream
+        ?.getAudioTracks()
+        .forEach((track) => (track.enabled = enabled));
+      setIsAudioEnabled(enabled);
+    },
+    [audioStream],
   );
 
   return {
-    stream,
+    videoStream,
+    audioStream,
     requestPermissions,
+    requestVideo,
+    requestAudio,
     stopMediaStream,
-    pauseVideoRecording,
-    resumeVideoRecording,
-    toggleMicTrack,
+    toggleVideo,
+    toggleAudio,
+    videoDeviceId,
+    audioDeviceId,
+    isVideoEnabled,
+    isAudioEnabled,
+    videoDevices,
+    audioDevices,
+    getMediaDevices,
+    mediaError,
+    hasVideoPermission: !!videoStream,
+    hasAudioPermission: !!audioStream,
   };
 };

--- a/packages/frontend/app/hooks/use-media-recorder.ts
+++ b/packages/frontend/app/hooks/use-media-recorder.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from "react";
 
-import { saveVideo, saveAudio } from "@/app/lib/client/media/mediaStorage"
+import { saveVideo, saveAudio } from "@/app/lib/client/media/mediaStorage";
 
 export const useMediaRecorder = (stream?: MediaStream | null) => {
   const mediaRecorderRefVideo = useRef<MediaRecorder | null>(null);

--- a/packages/frontend/app/lib/client/media/mediaStorage.ts
+++ b/packages/frontend/app/lib/client/media/mediaStorage.ts
@@ -11,15 +11,15 @@ const DB_CONFIG = {
 export interface MediaRecord {
   id: string;
   blob: Blob;
-  type: 'video' | 'audio';
+  type: "video" | "audio";
   updatedAt: number;
 }
 
 /**
  * IndexedDB 연결 및 초기화
  */
-const getDB = (): Promise<IDBDatabase> => {
-  return new Promise((resolve, reject) => {
+const getDB = () => {
+  return new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(DB_CONFIG.name, DB_CONFIG.version);
 
     request.onupgradeneeded = () => {
@@ -37,12 +37,12 @@ const getDB = (): Promise<IDBDatabase> => {
 /**
  * 미디어(비디오/오디오) Blob 저장
  */
-export const saveMedia = async (blob: Blob, type: 'video' | 'audio'): Promise<void> => {
+export const saveMedia = async (blob: Blob, type: "video" | "audio") => {
   const db = await getDB();
   const transaction = db.transaction(DB_CONFIG.store, "readwrite");
   const store = transaction.objectStore(DB_CONFIG.store);
 
-  const key = type === 'video' ? DB_CONFIG.keys.video : DB_CONFIG.keys.audio;
+  const key = type === "video" ? DB_CONFIG.keys.video : DB_CONFIG.keys.audio;
 
   store.put({
     id: key,
@@ -55,22 +55,22 @@ export const saveMedia = async (blob: Blob, type: 'video' | 'audio'): Promise<vo
 /**
  * 비디오 저장
  */
-export const saveVideo = async (blob: Blob): Promise<void> => {
-  return saveMedia(blob, 'video');
+export const saveVideo = async (blob: Blob) => {
+  return saveMedia(blob, "video");
 };
 
 /**
  * 오디오 저장
  */
-export const saveAudio = async (blob: Blob): Promise<void> => {
-  return saveMedia(blob, 'audio');
+export const saveAudio = async (blob: Blob) => {
+  return saveMedia(blob, "audio");
 };
 
-export const getLatestMedia = async (type: 'video' | 'audio'): Promise<Blob | null> => {
+export const getLatestMedia = async (type: "video" | "audio") => {
   const db = await getDB();
-  return new Promise((resolve) => {
+  return new Promise<Blob | null>((resolve) => {
     const transaction = db.transaction(DB_CONFIG.store, "readonly");
-    const key = type === 'video' ? DB_CONFIG.keys.video : DB_CONFIG.keys.audio;
+    const key = type === "video" ? DB_CONFIG.keys.video : DB_CONFIG.keys.audio;
     const request = transaction.objectStore(DB_CONFIG.store).get(key);
 
     request.onsuccess = () => resolve(request.result?.blob || null);
@@ -81,13 +81,13 @@ export const getLatestMedia = async (type: 'video' | 'audio'): Promise<Blob | nu
 /**
  * 비디오 조회
  */
-export const getLatestVideo = async (): Promise<Blob | null> => {
-  return getLatestMedia('video');
+export const getLatestVideo = async () => {
+  return getLatestMedia("video");
 };
 
 /**
  * 오디오 조회
  */
-export const getLatestAudio = async (): Promise<Blob | null> => {
-  return getLatestMedia('audio');
+export const getLatestAudio = async () => {
+  return getLatestMedia("audio");
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,7 +211,7 @@ importers:
         version: 16.0.10(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^30.0.0
-        version: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+        version: 30.2.0(@types/node@20.19.27)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -232,7 +232,7 @@ importers:
         version: 1.0.7(tailwindcss@4.1.18)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27))(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -6622,42 +6622,6 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.2.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.2.0
-      '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      '@types/node': 22.19.3
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
-      jest-haste-map: 30.2.0
-      jest-message-util: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-resolve-dependencies: 30.2.0
-      jest-runner: 30.2.0
-      jest-runtime: 30.2.0
-      jest-snapshot: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      jest-watcher: 30.2.0
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
@@ -9094,8 +9058,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -9121,7 +9085,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9132,21 +9096,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9157,7 +9121,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10040,15 +10004,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest-cli@30.2.0(@types/node@20.19.27):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@20.19.27)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -10078,7 +10042,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@20.19.27):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -10106,40 +10070,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.27
-      ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.2.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.3
-      ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10405,12 +10335,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest@30.2.0(@types/node@20.19.27):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest-cli: 30.2.0(@types/node@20.19.27)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11821,12 +11751,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest: 30.2.0(@types/node@20.19.27)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -11875,25 +11805,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
-
-  ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.27
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## **🎯 이슈 번호**

- close #57 

## **✅ 완료 작업 목록**

- [x]  인터뷰 준비 페이지 URL 경로 분리 (`/interview/[id]/ready`)
- [x]  인터뷰 준비 페이지 반응형 레이아웃 구현
- [x]  VideoStatus 컴포넌트 UI 개선 (aspect-ratio, 아이콘 상태 표시)
- [x]  미디어 권한 처리 로직 개선 (카메라/마이크 독립적 관리)
- [x]  시뮬레이터 레이아웃 전체 높이 구조 개선

---

## **🤔 주요 고민 및 해결 과정**

**[ 첫 번째 고민 ]**

- **고민**:  처음에 설계 하였던 인터뷰 진입 플로우에는 사용자가 `/interview/[id]`로 진입하는 순간 카메라/마이크 상태를 확인한 뒤, 조건이 충족되면 바로 인터뷰가 시작되는 구조였습니다. 하지만 moka와 이야기를 해보니.. 이 방식은 자동으로 확인을 하게 되어서 재입장 시 미디어 상태를 인지할 기회가 부족하고, 이 부분이 자연스러워 보이지 않다 라는 의견이 있어서 재입장 시에도 항상 현재 환경을 명시적으로 확인할 수 있도록 UX 를 개선하였습니다.


- **해결 과정**:
    - `/interview/[id]/ready` 경로를 새로 추가하여 인터뷰 준비 단계를 분리했습니다.
    - `/interview/[id]`는 실제 인터뷰 진행만 담당하도록 단순화했습니다.
    - 사용자는 준비 페이지에서 카메라/마이크 상태를 확인한 뒤 “면접 시작하기” 버튼을 눌러야만 인터뷰에 진입할 수 있습니다.

→ 재입장 시에도 항상 현재 환경을 명시적으로 확인할 수 있도록 UX를 개선했습니다.

**[ 두 번째 고민 ]**

- **문제점**: Chrome에서 카메라 권한만 거부하거나 제거했을 때, 오디오(마이크) 상태까지 함께 비활성화되는 문제가 발견되었습니다. 각 미디어 장치의 독립적인 상태 관리가 제대로 이루어지지 않았습니다.

**개선 내용**

- `useMediaPermissions` 훅에서 아래 상태를 개별적으로 관리하도록 수정
  - `hasVideoPermission`
  - `isVideoEnabled`
  - `hasAudioPermission`
- VideoStatus 컴포넌트에서 비디오/오디오 상태를 각각 판단하여 표시
- 텍스트 기반 상태 표시를 CircleCheck, CircleAlert 아이콘으로 변경하여 가독성 개선

→ 각 미디어 장치의 실제 상태를 보다 정확하게 사용자에게 전달할 수 있도록 했습니다.

---

## **💬 리뷰어에게**

- 스크린샷 부분을 보시면 준비 화면이 전체화면에서 너무 중간에 가있어 보이는 부분이 있습니다. 이 부분이 문제가 없어보이는지.. 
---

## **📸 스크린샷**

<img width="2531" height="1340" alt="image" src="https://github.com/user-attachments/assets/18469e3d-df80-4992-9010-b5df2904befe" />
<img width="924" height="1335" alt="image" src="https://github.com/user-attachments/assets/15cc515e-3a28-403d-b0cb-ad9636bc6cc9" />
