### PR TITLE
[Feature] 포트폴리오를 업로드할 수 있다

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -3,7 +3,7 @@ import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
 
-@Controller('documents')
+@Controller('document')
 export class DocumentController {
   constructor(private readonly documentService: DocumentService) {}
 

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,4 +1,21 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { DocumentService } from './document.service';
+import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
+import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
 
-@Controller('document')
-export class DocumentController {}
+@Controller('documents')
+export class DocumentController {
+  constructor(private readonly documentService: DocumentService) {}
+
+  @Post('portfolio/create')
+  async createPortfolioWithText(
+    @Body() body: CreatePortfolioTextRequestDto,
+  ): Promise<CreatePortfolioTextResponseDto> {
+    const userId = '1';
+    return this.documentService.createPortfolioWithText(
+      userId,
+      body.title,
+      body.content,
+    );
+  }
+}

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -12,7 +12,7 @@ export class DocumentController {
     @Body() body: CreatePortfolioTextRequestDto,
   ): Promise<CreatePortfolioTextResponseDto> {
     const userId = '1';
-    return this.documentService.createPortfolioWithText(
+    return await this.documentService.createPortfolioWithText(
       userId,
       body.title,
       body.content,

--- a/packages/backend/src/document/document.module.ts
+++ b/packages/backend/src/document/document.module.ts
@@ -4,6 +4,7 @@ import { DocumentService } from './document.service';
 import { PortfolioRepository } from './repositories/portfolio.repository';
 import { CoverLetterRepository } from './repositories/cover-letter.repository';
 import { DocumentRepository } from './repositories/document.repository';
+import { UserRepository } from '../user/user.repository';
 
 @Module({
   controllers: [DocumentController],
@@ -12,6 +13,7 @@ import { DocumentRepository } from './repositories/document.repository';
     PortfolioRepository,
     CoverLetterRepository,
     DocumentRepository,
+    UserRepository,
   ],
   exports: [PortfolioRepository, CoverLetterRepository, DocumentRepository],
 })

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PortfolioRepository } from './repositories/portfolio.repository';
 import { DocumentRepository } from './repositories/document.repository';
 import { UserRepository } from '../user/user.repository';
@@ -11,9 +7,9 @@ import { Portfolio } from './entities/portfolio.entity';
 @Injectable()
 export class DocumentService {
   constructor(
-    readonly userRepository: UserRepository,
-    readonly documentRepository: DocumentRepository,
-    readonly portfolioRepository: PortfolioRepository,
+    private readonly userRepository: UserRepository,
+    private readonly documentRepository: DocumentRepository,
+    private readonly portfolioRepository: PortfolioRepository,
   ) {}
 
   async createPortfolioWithText(

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,4 +1,48 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PortfolioRepository } from './repositories/portfolio.repository';
+import { DocumentRepository } from './repositories/document.repository';
+import { UserRepository } from '../user/user.repository';
+import { Portfolio } from './entities/portfolio.entity';
 
 @Injectable()
-export class DocumentService {}
+export class DocumentService {
+  constructor(
+    readonly userRepository: UserRepository,
+    readonly documentRepository: DocumentRepository,
+    readonly portfolioRepository: PortfolioRepository,
+  ) {}
+
+  async createPortfolioWithText(
+    userId: string,
+    title: string,
+    content: string,
+  ) {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundException('등록되지 않은 유저입니다.');
+    }
+
+    const document = await this.documentRepository.createPortfolioDocument(
+      title,
+      userId,
+    );
+
+    const portfolio: Portfolio = await this.portfolioRepository.save({
+      content,
+      document: { documentId: document.documentId },
+    });
+
+    return {
+      documentId: document.documentId,
+      type: document.type,
+      portfolioId: portfolio.portfolioId,
+      title: document.title,
+      content: portfolio.content,
+      createdAt: document.createdAt,
+    };
+  }
+}

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { DocumentRepository } from './repositories/document.repository';
 import { UserRepository } from '../user/user.repository';
+import { DataSource } from 'typeorm';
+import { Portfolio } from './entities/portfolio.entity';
+import { Document, DocumentType } from './entities/document.entity'; // Import 필요
 
 @Injectable()
 export class DocumentService {
@@ -8,6 +11,7 @@ export class DocumentService {
 
   constructor(
     private readonly userRepository: UserRepository,
+    private readonly dataSource: DataSource,
     private readonly documentRepository: DocumentRepository,
   ) {}
 
@@ -22,19 +26,27 @@ export class DocumentService {
       throw new NotFoundException('등록되지 않은 유저입니다.');
     }
 
-    const document = await this.documentRepository.createPortfolioDocument(
-      title,
-      userId,
-      content,
-    );
+    // [수정 1] transaction 실행 결과를 변수(savedDocument)로 받음 + await 필수
+    const savedDocument = await this.dataSource.transaction(async (manager) => {
+      const portfolio = new Portfolio();
+      portfolio.content = content;
+
+      const document = new Document();
+      document.title = title;
+      document.type = DocumentType.PORTFOLIO;
+      document.user = user;
+      document.portfolio = portfolio;
+
+      return await manager.save(Document, document);
+    });
 
     return {
-      documentId: document.documentId,
-      type: document.type,
-      portfolioId: document.portfolio.portfolioId,
-      title: document.title,
-      content: document.portfolio.content,
-      createdAt: document.createdAt,
+      documentId: savedDocument.documentId,
+      type: savedDocument.type,
+      portfolioId: savedDocument.portfolio.portfolioId,
+      title: savedDocument.title,
+      content: savedDocument.portfolio.content,
+      createdAt: savedDocument.createdAt,
     };
   }
 }

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,15 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { PortfolioRepository } from './repositories/portfolio.repository';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { DocumentRepository } from './repositories/document.repository';
 import { UserRepository } from '../user/user.repository';
-import { Portfolio } from './entities/portfolio.entity';
 
 @Injectable()
 export class DocumentService {
+  private readonly logger = new Logger(DocumentService.name);
+
   constructor(
     private readonly userRepository: UserRepository,
     private readonly documentRepository: DocumentRepository,
-    private readonly portfolioRepository: PortfolioRepository,
   ) {}
 
   async createPortfolioWithText(
@@ -19,25 +18,22 @@ export class DocumentService {
   ) {
     const user = await this.userRepository.findById(userId);
     if (!user) {
+      this.logger.warn(`User not found: userId=${userId}`);
       throw new NotFoundException('등록되지 않은 유저입니다.');
     }
 
     const document = await this.documentRepository.createPortfolioDocument(
       title,
       userId,
-    );
-
-    const portfolio: Portfolio = await this.portfolioRepository.save({
       content,
-      document: { documentId: document.documentId },
-    });
+    );
 
     return {
       documentId: document.documentId,
       type: document.type,
-      portfolioId: portfolio.portfolioId,
+      portfolioId: document.portfolio.portfolioId,
       title: document.title,
-      content: portfolio.content,
+      content: document.portfolio.content,
       createdAt: document.createdAt,
     };
   }

--- a/packages/backend/src/document/dto/create-portfolio-text-request.dto.ts
+++ b/packages/backend/src/document/dto/create-portfolio-text-request.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreatePortfolioTextRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/packages/backend/src/document/dto/create-portfolio-text-response.dto.ts
+++ b/packages/backend/src/document/dto/create-portfolio-text-response.dto.ts
@@ -1,0 +1,8 @@
+export class CreatePortfolioTextResponseDto {
+  documentId: string;
+  portfolioId: string;
+  type: string;
+  title: string;
+  content: string;
+  createdAt: Date;
+}

--- a/packages/backend/src/document/entities/document.entity.ts
+++ b/packages/backend/src/document/entities/document.entity.ts
@@ -34,7 +34,9 @@ export class Document {
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @OneToOne(() => Portfolio, (portfolio) => portfolio.document)
+  @OneToOne(() => Portfolio, (portfolio) => portfolio.document, {
+    cascade: true,
+  })
   portfolio: Portfolio;
 
   @OneToOne(() => CoverLetter, (coverLetter) => coverLetter.document)

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,11 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, In, Repository } from 'typeorm';
-import { Document } from '../entities/document.entity';
+import { Document, DocumentType } from '../entities/document.entity';
 
 @Injectable()
 export class DocumentRepository extends Repository<Document> {
   constructor(dataSource: DataSource) {
     super(Document, dataSource.createEntityManager());
+  }
+
+  async createPortfolioDocument(
+    title: string,
+    userId: string,
+  ): Promise<Document> {
+    return this.save({
+      type: DocumentType.PORTFOLIO,
+      title: title,
+      user: { userId },
+    });
   }
 
   async findByIds(ids: string[]): Promise<Document[]> {

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,42 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
-import { Document, DocumentType } from '../entities/document.entity';
-import { Portfolio } from '../entities/portfolio.entity';
+import { Document } from '../entities/document.entity';
 
 @Injectable()
 export class DocumentRepository extends Repository<Document> {
   constructor(private readonly dataSource: DataSource) {
     super(Document, dataSource.createEntityManager());
-  }
-
-  async createPortfolioDocument(
-    title: string,
-    userId: string,
-    content: string,
-  ): Promise<Document> {
-    return await this.dataSource.transaction(async (manager) => {
-      const documentRepo = manager.getRepository(Document);
-      const portfolioRepo = manager.getRepository(Portfolio);
-
-      // 1) Document 저장
-      const document = await documentRepo.save(
-        documentRepo.create({
-          type: DocumentType.PORTFOLIO,
-          title,
-          user: { userId },
-        }),
-      );
-
-      // 2) Portfolio 저장 (Document와 연결)
-      const portfolio = await portfolioRepo.save(
-        portfolioRepo.create({
-          content,
-          document: { documentId: document.documentId },
-        }),
-      );
-
-      document.portfolio = portfolio;
-      return document;
-    });
   }
 }

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,29 +1,42 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, In, Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Document, DocumentType } from '../entities/document.entity';
+import { Portfolio } from '../entities/portfolio.entity';
 
 @Injectable()
 export class DocumentRepository extends Repository<Document> {
-  constructor(dataSource: DataSource) {
+  constructor(private readonly dataSource: DataSource) {
     super(Document, dataSource.createEntityManager());
   }
 
   async createPortfolioDocument(
     title: string,
     userId: string,
+    content: string,
   ): Promise<Document> {
-    return this.save({
-      type: DocumentType.PORTFOLIO,
-      title: title,
-      user: { userId },
-    });
-  }
+    return await this.dataSource.transaction(async (manager) => {
+      const documentRepo = manager.getRepository(Document);
+      const portfolioRepo = manager.getRepository(Portfolio);
 
-  async findByIds(ids: string[]): Promise<Document[]> {
-    return this.find({
-      where: {
-        documentId: In(ids),
-      },
+      // 1) Document 저장
+      const document = await documentRepo.save(
+        documentRepo.create({
+          type: DocumentType.PORTFOLIO,
+          title,
+          user: { userId },
+        }),
+      );
+
+      // 2) Portfolio 저장 (Document와 연결)
+      const portfolio = await portfolioRepo.save(
+        portfolioRepo.create({
+          content,
+          document: { documentId: document.documentId },
+        }),
+      );
+
+      document.portfolio = portfolio;
+      return document;
     });
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mediapipe/tasks-vision':
         specifier: 0.10.22-rc.20250304
         version: 0.10.22-rc.20250304
+      jest:
+        specifier: ^30.2.0
+        version: 30.2.0
       pnpm:
         specifier: ^10.28.0
         version: 10.28.0
@@ -211,7 +214,7 @@ importers:
         version: 16.0.10(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^30.0.0
-        version: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+        version: 30.2.0(@types/node@20.19.27)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -232,7 +235,7 @@ importers:
         version: 1.0.7(tailwindcss@4.1.18)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27))(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -6622,42 +6625,6 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.2.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.2.0
-      '@jest/test-result': 30.2.0
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      '@types/node': 22.19.3
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
-      jest-haste-map: 30.2.0
-      jest-message-util: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-resolve-dependencies: 30.2.0
-      jest-runner: 30.2.0
-      jest-runtime: 30.2.0
-      jest-snapshot: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      jest-watcher: 30.2.0
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
@@ -9094,8 +9061,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -9121,7 +9088,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9132,21 +9099,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9157,7 +9124,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10040,15 +10007,34 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest-cli@30.2.0:
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.2.0(@types/node@20.19.27):
+    dependencies:
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      '@jest/test-result': 30.2.0
+      '@jest/types': 30.2.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.2.0(@types/node@20.19.27)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -10078,7 +10064,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest-config@30.2.0(@types/node@20.19.27):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/get-type': 30.1.0
@@ -10106,40 +10092,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.27
-      ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.2.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.3
-      ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10405,12 +10357,25 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
+  jest@30.2.0:
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest-cli: 30.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.2.0(@types/node@20.19.27):
+    dependencies:
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      '@jest/types': 30.2.0
+      import-local: 3.2.0
+      jest-cli: 30.2.0(@types/node@20.19.27)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11821,12 +11786,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.27))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 30.2.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest: 30.2.0(@types/node@20.19.27)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -11875,25 +11840,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
-
-  ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.27
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## 🎯 이슈 번호

- close #72 

## ✅ 완료 작업 목록

- [x] 텍스트 기반 포트폴리오 생성 API 구현 (`POST /documents/portfolio/create`)
- [x] 포트폴리오 생성 요청 DTO (`CreatePortfolioTextRequestDto`) 작성 및 유효성 검사 적용
- [x] `DocumentRepository`에 포트폴리오 생성 트랜잭션 로직 구현 (`createPortfolioDocument`)
  - `Document`와 `Portfolio` 엔티티 생성 시 트랜잭션 보장
  - `DataSource` 및 `manager`를 활용한 트랜잭션 처리

---

## 💬 리뷰어에게

- **트랜잭션 처리 위치**: 초기에는 Service 계층에서 `withRepository` 등을 고려했으나, 데이터 생성 및 관계 설정 로직이 DB 레이어에 밀접하다고 판단하여 `DocumentRepository` 내부로 로직을 캡슐화했습니다. 덕분에 Service 코드가 훨씬 깔끔해졌습니다.
- **임시 User ID**: 현재 인증 모듈 연동 전이라 Controller에서 `userId = '1'`로 하드코딩 되어 있습니다. 추후 인증 미들웨어 연동 시 수정이 필요합니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 트랜잭션 적용 방식 고민 ]**

- **문제점**: `createPortfolioWithText` 기능은 `Document` 테이블과 `Portfolio` 테이블에 모두 데이터를 저장해야 하는데, 중간에 실패할 경우 데이터 불일치가 발생할 수 있었습니다. 또한, `DocumentRepository`가 Custom Repository로 구현되어 있어 `manager.withRepository` 사용 시 생성자 주입 문제(`dataSource` 등)로 인한 호환성 이슈가 발생할 가능성이 있었습니다(실제로 Service 레이어에서 `manager.save`로 우회 시도 했었음).
- **해결 과정**:
    1. 처음에는 `DocumentService`에서 `dataSource.transaction`을 열고 `manager.withRepository`를 사용하려 했으나 복잡도가 증가함.
    2. 데이터 저장이 주 역할이므로 이를 `DocumentRepository`의 `createPortfolioDocument` 메서드 안으로 이동.
    3. Repository 내부에서 `this.dataSource.transaction`을 수행하고, 내부에서 `manager.getRepository(Document)`, `manager.getRepository(Portfolio)`를 통해 트랜잭션에 참여하는 Repository 인스턴스를 얻어 처리하는 방식으로 깔끔하게 해결.

---

## 📸 스크린샷

<img width="1134" height="58" alt="image" src="https://github.com/user-attachments/assets/4a37aee7-22cb-4fd4-91d5-f4b2bb990ec9" />

- **Curl 테스트 결과**: 정상적으로 `documentId`, `portfolioId`가 반환됨을 확인했습니다.
