### PR TITLE
[Feature] 사용자는 대시보드에서 포트폴리오, 자기소개서 목록을 볼 수 있다.

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {Body, Controller, Get, Param, Post, Query} from '@nestjs/common';
 import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
 import { ViewPortfolioResponseDto } from './dto/view-portfolio-response.dto';
+import {DocumentSummaryListResponse} from "./dto/document-summary.response.dto";
+import {DocumentSummaryRequest} from "./dto/document-summary.request.dto";
 
 @Controller('document')
 export class DocumentController {
@@ -26,5 +28,21 @@ export class DocumentController {
   ): Promise<ViewPortfolioResponseDto> {
     const userId = '1';
     return await this.documentService.viewPortfolio(userId, documentId);
+  }
+  @Get()
+  async getDocumentList(
+      @Query() dto: DocumentSummaryRequest,
+  ): Promise<DocumentSummaryListResponse> {
+    const userId = '1';
+    // 프론트의 페이지 시작은 1이지만 백엔드에선 0부터이다. 이를 맞추기 위해 1 빼준다.
+    dto.page = Math.max(0, dto.page - 1);
+    const { page, take, type, sort } = dto;
+    return await this.documentService.listDocuments(
+        userId,
+        page,
+        take,
+        type,
+        sort,
+    );
   }
 }

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -34,8 +34,7 @@ export class DocumentController {
       @Query() dto: DocumentSummaryRequest,
   ): Promise<DocumentSummaryListResponse> {
     const userId = '1';
-    // 프론트의 페이지 시작은 1이지만 백엔드에선 0부터이다. 이를 맞추기 위해 1 빼준다.
-    dto.page = Math.max(0, dto.page - 1);
+
     const { page, take, type, sort } = dto;
     return await this.documentService.listDocuments(
         userId,

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,10 +1,10 @@
-import {Body, Controller, Get, Param, Post, Query} from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
 import { ViewPortfolioResponseDto } from './dto/view-portfolio-response.dto';
-import {DocumentSummaryListResponse} from "./dto/document-summary.response.dto";
-import {DocumentSummaryRequest} from "./dto/document-summary.request.dto";
+import { DocumentSummaryListResponse } from './dto/document-summary.response.dto';
+import { DocumentSummaryRequest } from './dto/document-summary.request.dto';
 
 @Controller('document')
 export class DocumentController {
@@ -31,17 +31,17 @@ export class DocumentController {
   }
   @Get()
   async getDocumentList(
-      @Query() dto: DocumentSummaryRequest,
+    @Query() dto: DocumentSummaryRequest,
   ): Promise<DocumentSummaryListResponse> {
     const userId = '1';
 
     const { page, take, type, sort } = dto;
     return await this.documentService.listDocuments(
-        userId,
-        page,
-        take,
-        type,
-        sort,
+      userId,
+      page,
+      take,
+      type,
+      sort,
     );
   }
 }

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -70,4 +70,38 @@ export class DocumentService {
       createdAt: document.createdAt,
     };
   }
+
+  async listDocuments(
+      userId: string,
+      page: number,
+      take: number,
+      type: DocumentType | undefined,
+      sort: SortType,
+  ): Promise<DocumentSummaryListResponse> {
+    const [documents, count] = await this.documentRepository.findDocumentsPage(
+        userId,
+        page,
+        take,
+        type,
+        sort,
+    );
+
+    // 전체 페이지네이션 계산을 위해 올림을 사용
+    const totalPage = Math.ceil(count / take);
+
+    const documentList = documents.map((doc) => {
+      return {
+        documentId: doc.documentId,
+        title: doc.title,
+        type: doc.type,
+        createdAt: doc.createdAt,
+        modifiedAt: doc.modifiedAt,
+      };
+    });
+
+    return {
+      documents: documentList,
+      totalPage: totalPage,
+    }
+  }
 }

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -80,12 +80,14 @@ export class DocumentService {
       type: DocumentType | undefined,
       sort: SortType,
   ): Promise<DocumentSummaryListResponse> {
+    // 프론트의 페이지 시작은 1이지만 백엔드에선 0부터이다. 이를 맞추기 위해 값을 1 빼서 조정한다.
+    const adjustedPage = Math.max(0, page - 1);
     const [documents, count] = await this.documentRepository.findDocumentsPage(
-        userId,
-        page,
-        take,
-        type,
-        sort,
+      userId,
+      adjustedPage,
+      take,
+      type,
+      sort,
     );
 
     // 전체 페이지네이션 계산을 위해 올림을 사용

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -4,6 +4,8 @@ import { DataSource } from 'typeorm';
 import { Portfolio } from './entities/portfolio.entity';
 import { Document, DocumentType } from './entities/document.entity';
 import { UserService } from '../user/user.service';
+import {DocumentSummaryListResponse} from "./dto/document-summary.response.dto";
+import {SortType} from "./dto/document-summary.request.dto";
 
 @Injectable()
 export class DocumentService {

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -4,8 +4,8 @@ import { DataSource } from 'typeorm';
 import { Portfolio } from './entities/portfolio.entity';
 import { Document, DocumentType } from './entities/document.entity';
 import { UserService } from '../user/user.service';
-import {DocumentSummaryListResponse} from "./dto/document-summary.response.dto";
-import {SortType} from "./dto/document-summary.request.dto";
+import { DocumentSummaryListResponse } from './dto/document-summary.response.dto';
+import { SortType } from './dto/document-summary.request.dto';
 
 @Injectable()
 export class DocumentService {
@@ -74,11 +74,11 @@ export class DocumentService {
   }
 
   async listDocuments(
-      userId: string,
-      page: number,
-      take: number,
-      type: DocumentType | undefined,
-      sort: SortType,
+    userId: string,
+    page: number,
+    take: number,
+    type: DocumentType | undefined,
+    sort: SortType,
   ): Promise<DocumentSummaryListResponse> {
     // 프론트의 페이지 시작은 1이지만 백엔드에선 0부터이다. 이를 맞추기 위해 값을 1 빼서 조정한다.
     const adjustedPage = Math.max(0, page - 1);
@@ -106,6 +106,6 @@ export class DocumentService {
     return {
       documents: documentList,
       totalPage: totalPage,
-    }
+    };
   }
 }

--- a/packages/backend/src/document/dto/document-summary.request.dto.ts
+++ b/packages/backend/src/document/dto/document-summary.request.dto.ts
@@ -1,0 +1,27 @@
+import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
+import { DocumentType } from '../entities/document.entity';
+
+export enum SortType {
+  DESC = 'DESC',
+  ASC = 'ASC',
+}
+
+export class DocumentSummaryRequest {
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  page: number = 0;
+
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  take: number = 6;
+
+  @IsEnum(DocumentType)
+  @IsOptional()
+  type?: DocumentType;
+
+  @IsEnum(SortType)
+  @IsOptional()
+  sort: SortType = SortType.DESC;
+}

--- a/packages/backend/src/document/dto/document-summary.response.dto.ts
+++ b/packages/backend/src/document/dto/document-summary.response.dto.ts
@@ -1,0 +1,14 @@
+import { DocumentType } from '../entities/document.entity';
+
+export class DocumentSummaryListResponse {
+  documents: DocumentSummaryResponse[];
+  totalPage: number;
+}
+
+export class DocumentSummaryResponse {
+  documentId: string;
+  title: string;
+  type: DocumentType;
+  createdAt: Date;
+  modifiedAt: Date;
+}

--- a/packages/backend/src/document/entities/document.entity.ts
+++ b/packages/backend/src/document/entities/document.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   JoinColumn,
   OneToOne,
+  UpdateDateColumn,
 } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { Portfolio } from './portfolio.entity';
@@ -29,6 +30,9 @@ export class Document {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @UpdateDateColumn({ name: 'modified_at' })
+  modifiedAt: Date;
 
   @ManyToOne(() => User, (user) => user.documents)
   @JoinColumn({ name: 'user_id' })

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -23,4 +23,24 @@ export class DocumentRepository extends Repository<Document> {
       },
     });
   }
+
+  async findDocumentsPage(
+      userId: string,
+      page: number,
+      take: number,
+      type: DocumentType | undefined,
+      sort: SortType,
+  ): Promise<[Document[], number]> {
+    const skip = page * take;
+
+    const queryBuilder = this.createQueryBuilder('document');
+    queryBuilder.where('document.user_id = :userId', { userId });
+    if (type) {
+      queryBuilder.andWhere('document.type = :type', { type });
+    }
+
+    queryBuilder.orderBy('document.createdAt', sort).skip(skip).take(take);
+
+    return await queryBuilder.getManyAndCount();
+  }
 }

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Document, DocumentType } from '../entities/document.entity';
+import {SortType} from "../dto/document-summary.request.dto";
 
 @Injectable()
 export class DocumentRepository extends Repository<Document> {

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Document, DocumentType } from '../entities/document.entity';
-import {SortType} from "../dto/document-summary.request.dto";
+import { SortType } from '../dto/document-summary.request.dto';
 
 @Injectable()
 export class DocumentRepository extends Repository<Document> {
@@ -26,11 +26,11 @@ export class DocumentRepository extends Repository<Document> {
   }
 
   async findDocumentsPage(
-      userId: string,
-      page: number,
-      take: number,
-      type: DocumentType | undefined,
-      sort: SortType,
+    userId: string,
+    page: number,
+    take: number,
+    type: DocumentType | undefined,
+    sort: SortType,
   ): Promise<[Document[], number]> {
     const skip = page * take;
 

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -4,12 +4,22 @@ import { WinstonModule } from 'nest-winston';
 import { winstonOptions } from './common/logger/winston.config';
 
 import { SeedService } from './seed/seed.service';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: WinstonModule.createLogger(winstonOptions),
   });
-
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
   // 개발 환경 등에서 자동 시딩 실행
   const seedService = app.get(SeedService);
   await seedService.seed();


### PR DESCRIPTION
## 🎯 이슈 번호
- close #78

## ✅ 완료 작업 목록
- [x] 문서 목록 조회 API (`GET /document`) 구현
- [x] 문서 목록 조회 요청/응답 DTO (`DocumentSummaryRequest`, `DocumentSummaryResponse`) 추가
- [x] 페이지네이션, 정렬(최신순/오래된순), 필터링(전체/자소서/포폴) 기능 지원
- [x] dto 검증을 위한 전역 validation pipe 적용(`main.ts`) 
---
## 💬 리뷰어에게
- `DocumentController`에 `GET /document` 엔드포인트를 추가하여 문서 목록을 제공합니다.
- 프론트엔드에서는 페이지가 1부터 시작하지만, 백엔드는 0부터 시작하므로 컨트롤러에서 이를 보정(`page - 1`)해 주었습니다.
- `DocumentService`에서 리스트 조회와 함께 전체 페이지 수(`totalPage`)를 계산하여 반환합니다.
---
## 🤔 주요 고민 및 해결 과정 (선택)
**[ 요청 DTO의 검증 문제 ]**
- **문제점**: @IsNumber(), @IsEnum() 과 같이 api 요청 DTO에서 검증을 위해 데코레이터를 적극 사용하고 있었습니다. 하지만, 발리데이션 파이프가 적용되지 않아 서버가 실행되어도 dto 검증 단계없이 api를 실행중이였습니다. 잘못된 api 요청이 서비스, 레파지토리를 실행시켜 개발자가 예상하지 못한 동작이 있을 수 있습니다. 
- **해결 과정**: main.ts에 전역적으로 발리데이션 파이프를 적용시켰습니다. 세부 옵션은 아래와 같습니다.
``` js
async function bootstrap() {
  const app = await NestFactory.create(AppModule, {
    logger: WinstonModule.createLogger(winstonOptions),
  });
  // 발리데이션 파이프 적용
  app.useGlobalPipes(
    new ValidationPipe({
      transform: true,
      whitelist: true,
      forbidNonWhitelisted: true,
      transformOptions: {
        enableImplicitConversion: true,
      },
    }),
  );

```

**As Is**
잘못된 api 요청의 잘못된 응답 - page는 number 타입이여야 합니다. 하지만, 요청에서 타입을 잘못 설정했을 때 아래와 같은 서버 오류가 발생했습니다.
<img width="1292" height="970" alt="image" src="https://github.com/user-attachments/assets/9ee73ce4-c149-44f2-be85-f5a50d1eb121" />

**To Be**
잘못된 api 요청의 정상적인 응답 - validation 단계를 정상적으로 거쳐 BadRequest 응답이 나옵니다.
<img width="1282" height="1126" alt="image" src="https://github.com/user-attachments/assets/42229b71-ed12-4809-934f-1cf0d1f31947" />


**[ 페이지네이션 쿼리 ]**
- **문제점**: 페이징 쿼리를 서버에서 어떻게 하면 좋을지 고민해봤습니다. 
- **해결 과정**: 레포지토리의 페이징 조회 함수를 아래로 구현했습니다. 조회 로직은 LIMIT, OFFSET 기반입니다. 쿼리 빌더를 이용해 쿼리를 단순화 시켰고 DocumentType(포트폴리오, 자기소개서)의 유무에 따라 쿼리가 달라집니다. 페이지네이션을 위해 전체 page 수를 계산해야합니다. 따라서,  queryBuilder.getManyAndCount();를 사용해 전체 레코드의 수를 질의하여 page 수를 계산합니다.

``` js
//document.repository.ts  ...
async findDocumentsPage(
    userId: string,
    page: number,
    take: number,
    type: DocumentType | undefined,
    sort: SortType,
  ): Promise<[Document[], number]> {
    const skip = page * take;

    const queryBuilder = this.createQueryBuilder('document');
    queryBuilder.where('document.user_id = :userId', { userId });
    if (type) {
      queryBuilder.andWhere('document.type = :type', { type });
    }

    queryBuilder.orderBy('document.createdAt', sort).skip(skip).take(take);

    return await queryBuilder.getManyAndCount();
  }

```

**쿼리 결과**

``` sql
query: 
SELECT document.documents_id AS document_documents_id, document.type AS document_type, document.title AS document_title, document.created_at AS document_created_at, document.modified_at AS document_modified_at, document.user_id AS document_user_id
 FROM documents document
 WHERE document.user_id = ? AND document.type = ? 
ORDER BY document.created_at DESC 
LIMIT 6 
OFFSET 0 -- PARAMETERS: ["1","COVER"]
```

``` sql
query: 
SELECT COUNT(1) AS cnt 
FROM documents document 
WHERE document.user_id = ? AND document.type = ? -- PARAMETERS: ["1","COVER"]
```