### PR TITLE
[Feature] 사용자는 포트폴리오를 삭제할 수 있다.

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
@@ -29,6 +38,7 @@ export class DocumentController {
     const userId = '1';
     return await this.documentService.viewPortfolio(userId, documentId);
   }
+
   @Get()
   async getDocumentList(
     @Query() dto: DocumentSummaryRequest,
@@ -43,5 +53,14 @@ export class DocumentController {
       type,
       sort,
     );
+  }
+
+  @Delete(':documentId/portfolio')
+  @HttpCode(204)
+  async deletePortfolio(
+    @Param('documentId') documentId: string,
+  ): Promise<void> {
+    const userId = '1';
+    await this.documentService.deletePortfolio(userId, documentId);
   }
 }

--- a/packages/backend/src/document/entities/portfolio.entity.ts
+++ b/packages/backend/src/document/entities/portfolio.entity.ts
@@ -15,7 +15,9 @@ export class Portfolio {
   @Column({ name: 'content', type: 'text' })
   content: string;
 
-  @OneToOne(() => Document, (document) => document.portfolio)
+  @OneToOne(() => Document, (document) => document.portfolio, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'documents_id' })
   document: Document;
 }


### PR DESCRIPTION
## 🎯 이슈 번호
- close #74 

## ✅ 완료 작업 목록

- [x] 포트폴리오 삭제 API 구현 (`DELETE /documents/:documentId/portfolio`)
- [x] `DocumentService`에 트랜잭션 및 삭제 로직 추가
- [x] `DocumentRepository`에 Cascade 삭제를 활용한 `remove` 로직 구현
- [x] `Document` 및 `Portfolio` 엔티티 Cascade 설정 확인 및 검증

---

## 💬 리뷰어에게

- **Cascade 삭제 활용**: `Document`와 `Portfolio` 간의 `cascade: true` 설정을 활용하여, `Document` 삭제 시 `Portfolio`도 함께 삭제되도록 구현했습니다. 이를 위해 `DocumentRepository`의 조회 메서드(`findByIdAndUserId`)에서 `relations: { portfolio: true }`를 통해 연관 엔티티를 함께 로드하도록 처리했습니다.
- **삭제 로직 단순화**: 복잡한 수동 트랜잭션 대신, TypeORM의 `repository.remove()`가 Cascade 설정을 기반으로 연관 데이터를 안전하게 삭제하도록 처리했습니다.
- **반환 코드**: 성공적으로 삭제된 경우 204 No Content를 반환하며, 존재하지 않는 문서 삭제 시 404 Not Found 예외를 발생시킵니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ Cascade 삭제와 트랜잭션 ]**

- **문제점**: 처음에는 `DocumentRepository` 내부에서 수동으로 `Portfolio`와 `Document`를 각각 `delete`하는 방식으로 구현하려 했으나, 이는 코드가 복잡해지고 실수할 여지가 있었습니다. 또한 `delete()` 메서드는 TypeORM의 cascade 설정을 무시한다는 점을 확인했습니다.
- **해결 과정**:
    1. `Document` 엔티티의 `cascade: true`와 `Portfolio` 엔티티의 `onDelete: 'CASCADE'` 설정을 확인했습니다.
    2. Repository에서 `delete()` 대신 `remove()` 메서드를 사용하여 TypeORM이 어플리케이션 레벨에서 Cascade 삭제를 수행하도록 변경했습니다.
    3. `remove()`가 정상 작동하려면 연관 관계가 로드되어야 하므로 `findOne` 시 `relations` 옵션을 추가했습니다.
    4. Service 계층에서 트랜잭션을 시작하고, Repository에 `EntityManager`를 전달하거나 트랜잭션 스코프 내에서 실행되도록 하여 원자성을 보장했습니다.

---

## 📸 스크린샷
<img width="1880" height="1268" alt="image" src="https://github.com/user-attachments/assets/9fa410e3-17d2-4303-9ed6-66ee17777981" />

- **Curl 테스트 결과**:
    - **정상 삭제**: `DELETE /document/:id/portfolio` -> 204 No Content 반환 확인.
    - **미존재 문서 삭제**: `DELETE /document/:id/portfolio` -> 404 Not Found 메시지 반환 확인.
