### PR TITLE
[Feature] 사용자는 자기소개서를 등록할 수 있다.

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -24,7 +24,7 @@ export class DocumentController {
     );
   }
 
-  @Post('coverletter/create')
+  @Post('cover-letter/create')
   async createCoverLetter(
     @Body() body: CreateCoverLetterRequestDto,
   ): Promise<CreateCoverLetterResponseDto> {

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -5,6 +5,8 @@ import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-resp
 import { ViewPortfolioResponseDto } from './dto/view-portfolio-response.dto';
 import { DocumentSummaryListResponse } from './dto/document-summary.response.dto';
 import { DocumentSummaryRequest } from './dto/document-summary.request.dto';
+import { CreateCoverLetterRequestDto } from './dto/create-cover-letter-request.dto';
+import { CreateCoverLetterResponseDto } from './dto/create-cover-letter-response.dto';
 
 @Controller('document')
 export class DocumentController {
@@ -16,6 +18,18 @@ export class DocumentController {
   ): Promise<CreatePortfolioTextResponseDto> {
     const userId = '1';
     return await this.documentService.createPortfolioWithText(
+      userId,
+      body.title,
+      body.content,
+    );
+  }
+
+  @Post('coverletter/create')
+  async createCoverLetter(
+    @Body() body: CreateCoverLetterRequestDto,
+  ): Promise<CreateCoverLetterResponseDto> {
+    const userId = '1';
+    return await this.documentService.createCoverLetter(
       userId,
       body.title,
       body.content,

--- a/packages/backend/src/document/dto/create-cover-letter-request.dto.ts
+++ b/packages/backend/src/document/dto/create-cover-letter-request.dto.ts
@@ -1,0 +1,19 @@
+import { Type } from 'class-transformer';
+import { IsString, ValidateNested } from 'class-validator';
+
+export class CoverLetterQnA {
+  @IsString()
+  question: string;
+
+  @IsString()
+  answer: string;
+}
+
+export class CreateCoverLetterRequestDto {
+  @IsString()
+  title: string;
+
+  @ValidateNested({ each: true })
+  @Type(() => CoverLetterQnA)
+  content: CoverLetterQnA[];
+}

--- a/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
+++ b/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
@@ -1,0 +1,11 @@
+export class CreateCoverLetterResponseDto {
+  documentId: string;
+  coverletterId: string;
+  type: string;
+  title: string;
+  content: {
+    question: string;
+    answer: string;
+  }[];
+  createdAt: Date;
+}

--- a/packages/backend/src/document/entities/cover-letter.entity.ts
+++ b/packages/backend/src/document/entities/cover-letter.entity.ts
@@ -17,6 +17,8 @@ export class CoverLetter {
   @JoinColumn({ name: 'documents_id' })
   document: Document;
 
-  @OneToMany(() => CoverLetterQuestionAnswer, (qa) => qa.coverLetter)
+  @OneToMany(() => CoverLetterQuestionAnswer, (qa) => qa.coverLetter, {
+    cascade: true,
+  })
   questionAnswers: CoverLetterQuestionAnswer[];
 }

--- a/packages/backend/src/document/entities/document.entity.ts
+++ b/packages/backend/src/document/entities/document.entity.ts
@@ -43,6 +43,8 @@ export class Document {
   })
   portfolio: Portfolio;
 
-  @OneToOne(() => CoverLetter, (coverLetter) => coverLetter.document)
+  @OneToOne(() => CoverLetter, (coverLetter) => coverLetter.document, {
+    cascade: true,
+  })
   coverLetter: CoverLetter;
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #75 

## ✅ 완료 작업 목록

- [x] 자기소개서 업로드 API 구현 (`POST /document/coverletter/create`)
- [x] 자기소개서 생성 요청/응답 DTO 구현 (`CreateCoverLetterRequestDto`, `CreateCoverLetterResponseDto`)
- [x] DocumentService 내 자기소개서 생성 로직 구현 (Transactional 적용)
    - `Document` (type: COVER), `CoverLetter`, `CoverLetterQuestionAnswer` 엔티티 생성 및 연관관계 설정
- [x] Entity Cascade 옵션 추가
    - `Document` -> `CoverLetter` (cascade: true)
    - `CoverLetter` -> `CoverLetterQuestionAnswer` (cascade: true)

---

## 💬 리뷰어에게

자기소개서 업로드 기능을 구현했습니다.
클라이언트로부터 제목과 질문-답변 리스트를 받아, 하나의 트랜잭션 내에서 문서, 자기소개서, 질문-답변 엔티티를 모두 저장합니다.

### 테스트 방법
```bash
curl -X POST http://localhost:8000/document/coverletter/create \
-H "Content-Type: application/json" \
-d '{
    "title": "My Cover Letter",
    "content": [
        {
            "question": "Motivation",
            "answer": "I want to join."
        },
        {
            "question": "Strengths",
            "answer": "I am hard working."
        }
    ]
}'
```

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 데이터 저장 구조와 트랜잭션 ]**

- **문제점**: 자기소개서는 `Document` - `CoverLetter` - `CoverLetterQuestionAnswer` 3단계의 엔티티가 연결되어 있어, 저장 순서와 원자성이 중요했습니다.
- **해결 과정**: 
    - TypeORM `DataSource.transaction`을 사용하여 전체 과정을 하나의 트랜잭션으로 묶었습니다.
    - Entity 간 관계 설정에 `cascade: true` 옵션을 추가하여, 최상위 `Document` 혹은 `CoverLetter` 저장 시 하위 엔티티들이 자동으로 함께 저장되도록 구성하려 했으나, 
    - 명시적인 로직 흐름 파악과 확실한 저장을 위해 Service 코드 내에서는 객체 간 연결을 수동으로 명확히 한 후 저장하는 방식을 택했습니다. (Cascade 옵션은 엔티티에 추가해두었습니다)

---

## 📸 스크린샷
<img width="1878" height="482" alt="image" src="https://github.com/user-attachments/assets/a11c5791-a949-47b8-8afc-e54555372193" />

