### PR TITLE
[Feature] 사용자는 자기소개서를 상세 조회할 수 있다

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Delete, HttpCode } from '@nestjs/common';
 import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
 import { ViewPortfolioResponseDto } from './dto/view-portfolio-response.dto';
+import { ViewCoverLetterResponseDto } from './dto/view-cover-letter-response.dto';
 import { DocumentSummaryListResponse } from './dto/document-summary.response.dto';
 import { DocumentSummaryRequest } from './dto/document-summary.request.dto';
+import { CreateCoverLetterRequestDto } from './dto/create-cover-letter-request.dto';
+import { CreateCoverLetterResponseDto } from './dto/create-cover-letter-response.dto';
 
 @Controller('document')
 export class DocumentController {
@@ -20,6 +23,40 @@ export class DocumentController {
       body.title,
       body.content,
     );
+  }
+
+  @Post('cover-letter/create')
+  async createCoverLetter(
+    @Body() body: CreateCoverLetterRequestDto,
+  ): Promise<CreateCoverLetterResponseDto> {
+    const userId = '1';
+    return await this.documentService.createCoverLetter(
+      userId,
+      body.title,
+      body.content,
+    );
+  }
+
+  @Delete(':documentId/cover-letter')
+  @HttpCode(204)
+  async deleteCoverLetter(@Param('documentId') documentId: string) {
+    const userId = '1';
+    await this.documentService.deleteCoverLetter(userId, documentId);
+  }
+
+  @Delete(':documentId/portfolio')
+  @HttpCode(204)
+  async deletePortfolio(@Param('documentId') documentId: string) {
+    const userId = '1';
+    await this.documentService.deletePortfolio(userId, documentId);
+  }
+
+  @Get(':documentId/cover-letter')
+  async viewCoverLetter(
+    @Param('documentId') documentId: string,
+  ): Promise<ViewCoverLetterResponseDto> {
+    const userId = '1';
+    return await this.documentService.viewCoverLetter(userId, documentId);
   }
 
   @Get(':documentId/portfolio')

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -33,7 +33,7 @@ export class DocumentController {
       body.content,
     );
   }
-  
+
   @Get(':documentId/portfolio')
   async viewPortfolio(
     @Param('documentId') documentId: string,
@@ -68,7 +68,7 @@ export class DocumentController {
     const userId = '1';
     return await this.documentService.viewCoverLetter(userId, documentId);
   }
-  
+
   @Delete(':documentId/cover-letter')
   @HttpCode(204)
   async deleteCoverLetter(@Param('documentId') documentId: string) {
@@ -91,3 +91,4 @@ export class DocumentController {
       sort,
     );
   }
+}

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { DocumentRepository } from './repositories/document.repository';
 import { DataSource } from 'typeorm';
 import { Portfolio } from './entities/portfolio.entity';
@@ -48,14 +53,15 @@ export class DocumentService {
       createdAt: savedDocument.createdAt,
     };
   }
-  
+
   async viewPortfolio(userId: string, documentId: string) {
     const user = await this.userService.findExistingUser(userId);
 
-    const document = await this.documentRepository.findOneWithPortfolioByDocumentIdAndUserId(
-      user.userId,
-      documentId,
-    );
+    const document =
+      await this.documentRepository.findOneWithPortfolioByDocumentIdAndUserId(
+        user.userId,
+        documentId,
+      );
 
     if (!document) {
       this.logger.warn(
@@ -73,13 +79,14 @@ export class DocumentService {
       createdAt: document.createdAt,
     };
   }
-  
+
   async deletePortfolio(userId: string, documentId: string) {
     const user = await this.userService.findExistingUser(userId);
-    const document = await this.documentRepository.findOneWithPortfolioById(
-      user.userId,
-      documentId,
-    );
+    const document =
+      await this.documentRepository.findOneWithPortfolioByDocumentIdAndUserId(
+        user.userId,
+        documentId,
+      );
 
     if (!document) {
       this.logger.warn(`등록되지 않은 문서입니다. documentId=${documentId}`);
@@ -92,7 +99,7 @@ export class DocumentService {
       throw new InternalServerErrorException('문서 삭제에 실패했습니다.');
     }
   }
-  
+
   async createCoverLetter(
     userId: string,
     title: string,
@@ -106,7 +113,7 @@ export class DocumentService {
         const questionAnswer = new CoverLetterQuestionAnswer();
         questionAnswer.question = qa.question;
         questionAnswer.answer = qa.answer;
-        questionAnswer.coverLetter = coverLetter; // Explicitly map inverse relation
+        questionAnswer.coverLetter = coverLetter;
         return questionAnswer;
       });
 
@@ -114,7 +121,7 @@ export class DocumentService {
       document.title = title;
       document.type = DocumentType.COVER;
       document.user = user;
-      
+
       const savedDocument = await manager.save(Document, document);
 
       coverLetter.document = savedDocument;
@@ -125,7 +132,7 @@ export class DocumentService {
         return qa;
       });
       const savedQAs = await manager.save(CoverLetterQuestionAnswer, qas);
-      
+
       savedDocument.coverLetter = savedCoverLetter;
       savedDocument.coverLetter.questionAnswers = savedQAs;
 
@@ -134,7 +141,7 @@ export class DocumentService {
 
     return {
       documentId: savedDocument.documentId,
-      coverletterId: savedDocument.coverLetter.coverLetterId,
+      coverLetterId: savedDocument.coverLetter.coverLetterId,
       type: savedDocument.type,
       title: savedDocument.title,
       content: savedDocument.coverLetter.questionAnswers.map((qa) => ({
@@ -148,10 +155,11 @@ export class DocumentService {
   async viewCoverLetter(userId: string, documentId: string) {
     const user = await this.userService.findExistingUser(userId);
 
-    const document = await this.documentRepository.findOneWithCoverLetterByDocumentIdAndUserId(
-      user.userId,
-      documentId,
-    );
+    const document =
+      await this.documentRepository.findOneWithCoverLetterByDocumentIdAndUserId(
+        user.userId,
+        documentId,
+      );
 
     if (!document) {
       this.logger.warn(
@@ -161,13 +169,15 @@ export class DocumentService {
     }
 
     if (!document.coverLetter) {
-        this.logger.error(`CoverLetter data missing for documentId=${documentId}`);
-        throw new InternalServerErrorException('자기소개서 데이터가 없습니다.');
+      this.logger.error(
+        `CoverLetter data missing for documentId=${documentId}`,
+      );
+      throw new InternalServerErrorException('자기소개서 데이터가 없습니다.');
     }
 
     return {
       documentId: document.documentId,
-      coverletterId: document.coverLetter.coverLetterId,
+      coverLetterId: document.coverLetter.coverLetterId,
       type: document.type,
       title: document.title,
       content: document.coverLetter.questionAnswers.map((qa) => ({
@@ -180,10 +190,11 @@ export class DocumentService {
 
   async deleteCoverLetter(userId: string, documentId: string) {
     const user = await this.userService.findExistingUser(userId);
-    const document = await this.documentRepository.findCoverLetterDocumentByDocumentIdAndUserId(
-      user.userId,
-      documentId,
-    );
+    const document =
+      await this.documentRepository.findCoverLetterDocumentByDocumentIdAndUserId(
+        user.userId,
+        documentId,
+      );
 
     if (!document) {
       throw new NotFoundException('문서를 찾을 수 없습니다.');

--- a/packages/backend/src/document/dto/create-cover-letter-request.dto.ts
+++ b/packages/backend/src/document/dto/create-cover-letter-request.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsNotEmpty, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CoverLetterQnA {
+  @IsString()
+  @IsNotEmpty()
+  question: string;
+
+  @IsString()
+  @IsNotEmpty()
+  answer: string;
+}
+
+export class CreateCoverLetterRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CoverLetterQnA)
+  content: CoverLetterQnA[];
+}

--- a/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
+++ b/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
@@ -1,0 +1,11 @@
+import { DocumentType } from '../entities/document.entity';
+import { CoverLetterQnA } from './create-cover-letter-request.dto';
+
+export class CreateCoverLetterResponseDto {
+  documentId: string;
+  coverletterId: string;
+  type: DocumentType;
+  title: string;
+  content: CoverLetterQnA[];
+  createdAt: Date;
+}

--- a/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
+++ b/packages/backend/src/document/dto/create-cover-letter-response.dto.ts
@@ -3,7 +3,7 @@ import { CoverLetterQnA } from './create-cover-letter-request.dto';
 
 export class CreateCoverLetterResponseDto {
   documentId: string;
-  coverletterId: string;
+  coverLetterId: string;
   type: DocumentType;
   title: string;
   content: CoverLetterQnA[];

--- a/packages/backend/src/document/dto/view-cover-letter-response.dto.ts
+++ b/packages/backend/src/document/dto/view-cover-letter-response.dto.ts
@@ -1,0 +1,13 @@
+import { DocumentType } from '../entities/document.entity';
+
+export class ViewCoverLetterResponseDto {
+  documentId: string;
+  coverletterId: string;
+  type: DocumentType;
+  title: string;
+  content: {
+    question: string;
+    answer: string;
+  }[];
+  createdAt: Date;
+}

--- a/packages/backend/src/document/dto/view-cover-letter-response.dto.ts
+++ b/packages/backend/src/document/dto/view-cover-letter-response.dto.ts
@@ -2,7 +2,7 @@ import { DocumentType } from '../entities/document.entity';
 
 export class ViewCoverLetterResponseDto {
   documentId: string;
-  coverletterId: string;
+  coverLetterId: string;
   type: DocumentType;
   title: string;
   content: {

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -25,6 +25,24 @@ export class DocumentRepository extends Repository<Document> {
     });
   }
 
+  async findOneWithCoverLetterByDocumentIdAndUserId(
+    userId: string,
+    documentId: string,
+  ): Promise<Document | null> {
+    return await this.findOne({
+      where: {
+        documentId,
+        user: { userId },
+        type: DocumentType.COVER,
+      },
+      relations: {
+        coverLetter: {
+          questionAnswers: true,
+        },
+      },
+    });
+  }
+
   async findDocumentsPage(
     userId: string,
     page: number,


### PR DESCRIPTION
## 🎯 이슈 번호

- close #77 

## ✅ 완료 작업 목록

- [x] 자기소개서 상세 조회 API 구현 (`GET /document/:documentId/cover-letter`)
- [x] `ViewCoverLetterResponseDto` 생성 및 적용 (Q&A 리스트 반환)
- [x] `DocumentRepository` 내 `findOneWithCoverLetterById` 메서드 추가 (CoverLetter 및 QuestionAnswers 연관관계 로딩)
- [x] `DocumentService` 내 `viewCoverLetter` 메서드 구현
- [x] (Hotfix) 누락되었던 자기소개서 생성(`create`) 및 삭제(`delete`) 관련 로직 복구

---

## 🤔 주요 고민 및 해결 과정

**[ 자기소개서 상세 데이터 구조 매핑 ]**

- **문제점**: `Portfolio`는 단일 `content` 문자열을 가지지만, `CoverLetter`는 여러 개의 질의응답(`QuestionAnswer`) 쌍으로 이루어져 있어 데이터 구조가 다릅니다.
- **해결**: `ViewCoverLetterResponseDto`에서 `content` 필드를 `CoverLetterQnA[]` 타입으로 정의하여, 클라이언트가 구조화된 질의응답 데이터를 받을 수 있도록 구현했습니다.

**[ 연관 관계 로딩 최적화 ]**

- **문제점**: 자기소개서 조회 시 `Document` -> `CoverLetter` -> `QuestionAnswers`로 이어지는 3단계 깊이의 데이터가 필요했습니다.
- **해결**: TypeORM의 `relations` 옵션을 사용하여 `findOneWithCoverLetterById` 리포지토리 메서드에서 한 번의 쿼리로 필요한 모든 연관 데이터를 조회하도록 최적화했습니다.

---

## 💬 리뷰어에게

- 이번 PR의 핵심은 **상세 조회(Detail View)** 기능입니다.
- 개발 과정에서 로컬 테스트를 위해 누락되어 있던 생성/삭제 API도 함께 복구하여 테스트를 진행했습니다. 엔터티(`Entity`) 파일의 변경사항은 포함되지 않았으므로 로직 위주로 리뷰 부탁드립니다.

---

## 📸 스크린샷 (API 검증 결과)

**[GET /document/:documentId/cover-letter Response]**
<img width="927" height="357" alt="image" src="https://github.com/user-attachments/assets/2a4ae0a8-f346-49f1-a327-f512ca37e066" />

```json
{
  "documentId": "9",
  "coverletterId": "2",
  "type": "COVER",
  "title": "Detailed Cover Letter",
  "content": [
    {
      "question": "Q1",
      "answer": "A1"
    },
    {
      "question": "Q2",
      "answer": "A2"
    }
  ],
  "createdAt": "2026-01-23T02:20:23.684Z"
}
```