### PR TITLE
[Feature] 사용자는 대시보드에서 지난 면접 목록을 볼 수 있다.

### DIFF
--- a/packages/backend/src/interview/dto/interview-summary.request.dto.ts
+++ b/packages/backend/src/interview/dto/interview-summary.request.dto.ts
@@ -1,0 +1,27 @@
+import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
+import { InterviewType } from '../entities/interview.entity';
+
+export enum SortType {
+    DESC = 'DESC',
+    ASC = 'ASC',
+}
+
+export class InterviewSummaryRequest {
+    @IsNumber()
+    @Min(0)
+    @IsOptional()
+    page: number = 0;
+
+    @IsNumber()
+    @Min(1)
+    @IsOptional()
+    take: number = 6;
+
+    @IsEnum(InterviewType)
+    @IsOptional()
+    type?: InterviewType;
+
+    @IsEnum(SortType)
+    @IsOptional()
+    sort: SortType = SortType.DESC;
+}

--- a/packages/backend/src/interview/dto/interview-summary.response.dto.ts
+++ b/packages/backend/src/interview/dto/interview-summary.response.dto.ts
@@ -1,0 +1,13 @@
+import { InterviewType } from '../entities/interview.entity';
+
+export class InterviewSummaryListResponse {
+    interviews: InterviewSummaryResponse[];
+    totalPage: number;
+}
+
+export class InterviewSummaryResponse {
+    interviewId: string;
+    title: string;
+    type: InterviewType;
+    createdAt: Date;
+}

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -8,6 +8,7 @@ import {
   Post,
   UploadedFile,
   UseInterceptors,
+  Query,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { InterviewService } from './interview.service';
@@ -25,11 +26,13 @@ import { CreateInterviewRequestDto } from './dto/create-interview-request.dto';
 import { CreateInterviewResponseDto } from './dto/create-interview-response.dto';
 import { CreateFeedbackRequest } from './dto/create-feedback-request.dto';
 import { InterviewFeedbackResponse } from './dto/interview-feedback-response.dto';
+import { InterviewSummaryRequest } from './dto/interview-summary.request.dto';
+import { InterviewSummaryListResponse } from './dto/interview-summary.response.dto';
 
 @Controller('interview')
 export class InterviewController {
   private readonly logger = new Logger(InterviewController.name);
-  constructor(private readonly interviewService: InterviewService) {}
+  constructor(private readonly interviewService: InterviewService) { }
 
   @Post('tech/create')
   async createTechInterview(
@@ -138,5 +141,20 @@ export class InterviewController {
     // 인증이 없기 때문에 userId를 상수화
     const userId = '1';
     return this.interviewService.findInterviewFeedback(userId, interviewId);
+  }
+
+  @Get()
+  async getInterviewList(
+    @Query() dto: InterviewSummaryRequest,
+  ): Promise<InterviewSummaryListResponse> {
+    const userId = '1';
+    const { page, take, type, sort } = dto;
+    return await this.interviewService.listInterviews(
+      userId,
+      page,
+      take,
+      type,
+      sort,
+    );
   }
 }

--- a/packages/backend/src/interview/interview.repository.ts
+++ b/packages/backend/src/interview/interview.repository.ts
@@ -1,6 +1,7 @@
 import { DataSource, Repository } from 'typeorm';
-import { Interview } from './entities/interview.entity';
+import { Interview, InterviewType } from './entities/interview.entity';
 import { Injectable } from '@nestjs/common';
+import { SortType } from './dto/interview-summary.request.dto';
 
 @Injectable()
 export class InterviewRepository extends Repository<Interview> {
@@ -13,5 +14,26 @@ export class InterviewRepository extends Repository<Interview> {
     relations: string[] = [],
   ): Promise<Interview | null> {
     return this.findOne({ where: { interviewId: interviewId }, relations });
+  }
+
+  async findInterviewsPage(
+    userId: string,
+    page: number,
+    take: number,
+    type: InterviewType | undefined,
+    sort: SortType,
+  ): Promise<[Interview[], number]> {
+    const skip = page * take;
+
+    const queryBuilder = this.createQueryBuilder('interview');
+    queryBuilder.where('interview.user_id = :userId', { userId });
+
+    if (type) {
+      queryBuilder.andWhere('interview.type = :type', { type });
+    }
+
+    queryBuilder.orderBy('interview.createdAt', sort).skip(skip).take(take);
+
+    return await queryBuilder.getManyAndCount();
   }
 }

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -25,6 +25,8 @@ import { DocumentRepository } from '../document/repositories/document.repository
 import { User } from '../user/entities/user.entity';
 import { InterviewFeedbackService } from './interview-feedback.service';
 import { InterviewFeedbackResponse } from './dto/interview-feedback-response.dto';
+import { InterviewSummaryListResponse } from './dto/interview-summary.response.dto';
+import { SortType } from './dto/interview-summary.request.dto';
 
 @Injectable()
 export class InterviewService {
@@ -41,7 +43,7 @@ export class InterviewService {
     private readonly coverLetterRepository: CoverLetterRepository,
     private readonly documentRepository: DocumentRepository,
     private readonly interviewFeedBackService: InterviewFeedbackService,
-  ) {}
+  ) { }
 
   async calculateInterviewTime(
     userId: string,
@@ -296,6 +298,40 @@ export class InterviewService {
     return {
       score: interview.score,
       feedback: interview.feedback,
+    };
+  }
+
+  async listInterviews(
+    userId: string,
+    page: number,
+    take: number,
+    type: InterviewType | undefined,
+    sort: SortType,
+  ): Promise<InterviewSummaryListResponse> {
+    const adjustedPage = Math.max(0, page - 1);
+    const [interviews, count] =
+      await this.interviewRepository.findInterviewsPage(
+        userId,
+        adjustedPage,
+        take,
+        type,
+        sort,
+      );
+
+    const totalPage = Math.ceil(count / take);
+
+    const interviewList = interviews.map((interview) => {
+      return {
+        interviewId: interview.interviewId,
+        title: interview.title,
+        type: interview.type,
+        createdAt: interview.createdAt,
+      };
+    });
+
+    return {
+      interviews: interviewList,
+      totalPage: totalPage,
     };
   }
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #79

## ✅ 완료 작업 목록

- [x] 인터뷰 목록 조회 API (`GET /interview`) 구현
- [x] 인터뷰 목록 조회 요청/응답 DTO (`InterviewSummaryRequest`, `InterviewSummaryResponse`) 추가
- [x] 페이지네이션, 정렬(최신순/오래된순), 필터링(면접 유형) 기능 지원

---

## 💬 리뷰어에게

- #82 와 로직이 동일하게 작성이 되어있습니다. 차이점은 목록 조회하고자 하는 대상(면접 서류, 면접)만 다릅니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 페이징 코드의 분리]**

- **문제점**: 현재 대시보드 목록 조회와 로직이 매우 유사합니다. 그래서, 면접 목록 조회 코드를 이전에 구현한 코드들과 서비스 코드를 공통화 시켜서 재사용성을 높여볼까 고민되었습니다.
- **해결 과정**: 여러 고민 끝에 비슷한 로직이지만 따로 코드를 구현했습니다. 분리의 이유는 면접 서류와 면접이 도메인이 달라 유지보수하기 어려울 것이라고 생각했기 떄문입니다. 현재 두 로직은 비슷하여 공통 모듈화 시켜 사용한다면 추후에 기획의 변경으로 기능 추가, 소거로 인해 코드 분리가 필요할 때 변경 비용이 더 크다고 판단했습니다. 

## 스크린샷
<img width="651" height="581" alt="image" src="https://github.com/user-attachments/assets/9734d61a-9677-48af-acf7-76f2582a90bb" />
