### PR TITLE
[deploy] cd 파이프라인 버그 수정

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/auto_assign.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Monorepo pnpm CI
 
 on:
-  push:
-    branches: ["main", "develop"]
   pull_request:
     branches: ["main", "develop"]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
             docker-compose -f packages/backend/docker-compose.dev.yml up -d --remove-orphans
             
             # 6. 정리 (이전 버전 이미지 삭제)
-            docker image prune -f
+            docker image prune -a
 
             END_TIME=$(date +%s)
             DURATION=$((END_TIME - START_TIME))

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - '${PORT}:${PORT}'
     env_file:
-      - ./packages/backend/.env
+      - .env
     depends_on:
       - mysql
     networks:

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - '${PORT}:${PORT}'
     env_file:
-      - ../../../cicd/web23-PSI/packages/backend/.env
+      - ./packages/backend/.env
     depends_on:
       - mysql
     networks:


### PR DESCRIPTION
## 🎯 이슈 번호

- close #89 


## ✅ 완료 작업 목록

- [x] `.github/workflows/auto_assign.yml` 파일 생성
- [x] PR 생성 시 Reviewer 및 Assignee 자동 지정 기능 활성화
- [x] `docker-compose.dev.yml` 내 env_file 상대 경로 수정 (`./packages/backend/.env`)
- [x] `.github/workflows/ci.yml`의 `push` 트리거 제거
- [x] 배포 스크립트 내 Docker 이미지 정리 명령어 수정 (`prune -f` → `prune -a`)

---

## 💬 리뷰어에게

`auto_assign` 설정 파일(`.github/auto_assign.yml`)은 존재했으나, 이를 실행할 GitHub Actions Workflow 파일이 누락되어 있어 기능이 동작하지 않았습니다.
이에 `kentaro-m/auto-assign-action`을 사용하는 워크플로우 파일을 추가하여 해당 기능이 정상 동작하도록 수정했습니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ Workflow 파일 누락 확인 ]**

- **문제점**: `auto_assign.yml` 설정 파일은 있었지만, 실제 액션을 수행하는 워크플로우 파일이 없었습니다.
- **해결 과정**: `.github/workflows/` 디렉토리에 `auto_assign.yml` 파일을 신규 생성하고, 기존 설정 파일을 참조하도록 구성했습니다.

---


**[ docker-compose env_file 경로 수정 ]**

- **문제점**: `docker-compose` 실행 위치 변경(루트)에 따라 `env_file` 경로 인식이 실패할 가능성이 있었습니다.
- **해결 과정**: `env_file` 경로를 프로젝트 루트 기준인 `./packages/backend/.env`로 명시적으로 수정하여, 루트 디렉토리에서 실행 시에도 정상적으로 환경 변수 파일을 찾을 수 있도록 개선했습니다.

**[ CI push 트리거 제거 ]**

- **문제점**: `push`와 `pull_request` 이벤트가 중복으로 설정되어 있어, PR 생성 시 불필요하게 CI가 중복 실행되는 문제가 있었습니다.
- **해결 과정**: `ci.yml`에서 `push` 트리거를 제거하여 PR 이벤트 발생 시에만 CI가 동작하도록 최적화했습니다.

**[ Docker 이미지 정리 명령어 수정 ]**

- **문제점**: 기존 `docker image prune -f` 사용 시, Dangling 이미지(태그 없는 이미지)만 삭제되어, 사용하지 않는 구버전 이미지가 계속 누적되는 문제가 있었습니다.
- **해결 과정**: `docker image prune -a`로 변경하여, 현재 실행 중인 컨테이너가 사용하지 않는 모든 이미지를 삭제하도록 개선했습니다. 이를 통해 디스크 공간을 보다 효율적으로 관리할 수 있습니다.

---
## 📸 스크린샷
