### PR TITLE
[Feature] 사용자는 포트폴리오를 수정할 수 있다.

### DIFF
--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Post,
+  Patch,
   Query,
   Delete,
   HttpCode,
@@ -11,12 +12,13 @@ import {
 import { DocumentService } from './document.service';
 import { CreatePortfolioTextRequestDto } from './dto/create-portfolio-text-request.dto';
 import { CreatePortfolioTextResponseDto } from './dto/create-portfolio-text-response.dto';
-import { ViewPortfolioResponseDto } from './dto/view-portfolio-response.dto';
+import { PortfolioDetailResponseDto } from './dto/portfolio-detail-response.dto';
 import { ViewCoverLetterResponseDto } from './dto/view-cover-letter-response.dto';
 import { DocumentSummaryListResponse } from './dto/document-summary.response.dto';
 import { DocumentSummaryRequest } from './dto/document-summary.request.dto';
 import { CreateCoverLetterRequestDto } from './dto/create-cover-letter-request.dto';
 import { CreateCoverLetterResponseDto } from './dto/create-cover-letter-response.dto';
+import { UpdatePortfolioRequestDto } from './dto/update-portfolio-request.dto';
 
 @Controller('document')
 export class DocumentController {
@@ -37,9 +39,23 @@ export class DocumentController {
   @Get(':documentId/portfolio')
   async viewPortfolio(
     @Param('documentId') documentId: string,
-  ): Promise<ViewPortfolioResponseDto> {
+  ): Promise<PortfolioDetailResponseDto> {
     const userId = '1';
     return await this.documentService.viewPortfolio(userId, documentId);
+  }
+
+  @Patch(':documentId/portfolio')
+  async updatePortfolio(
+    @Param('documentId') documentId: string,
+    @Body() body: UpdatePortfolioRequestDto,
+  ): Promise<PortfolioDetailResponseDto> {
+    const userId = '1';
+    return await this.documentService.updatePortfolio(
+      userId,
+      documentId,
+      body.title,
+      body.content,
+    );
   }
 
   @Delete(':documentId/portfolio')

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -77,6 +77,7 @@ export class DocumentService {
       title: document.title,
       content: document.portfolio.content,
       createdAt: document.createdAt,
+      modifiedAt: document.modifiedAt,
     };
   }
 
@@ -98,6 +99,46 @@ export class DocumentService {
       this.logger.warn(`문서 삭제에 실패했습니다. documentId=${documentId}`);
       throw new InternalServerErrorException('문서 삭제에 실패했습니다.');
     }
+  }
+
+  async updatePortfolio(
+    userId: string,
+    documentId: string,
+    title?: string,
+    content?: string,
+  ) {
+    const user = await this.userService.findExistingUser(userId);
+    const document =
+      await this.documentRepository.findOneWithPortfolioByDocumentIdAndUserId(
+        user.userId,
+        documentId,
+      );
+
+    if (!document) {
+      this.logger.warn(
+        `등록되지 않은 포트폴리오입니다. documentId=${documentId}`,
+      );
+      throw new NotFoundException('등록되지 않은 문서입니다');
+    }
+
+    if (title) {
+      document.title = title;
+    }
+    if (content) {
+      document.portfolio.content = content;
+    }
+
+    const savedDocument = await this.documentRepository.save(document);
+
+    return {
+      documentId: savedDocument.documentId,
+      type: savedDocument.type,
+      portfolioId: savedDocument.portfolio.portfolioId,
+      title: savedDocument.title,
+      content: savedDocument.portfolio.content,
+      createdAt: savedDocument.createdAt,
+      modifiedAt: savedDocument.modifiedAt,
+    };
   }
 
   async createCoverLetter(

--- a/packages/backend/src/document/dto/portfolio-detail-response.dto.ts
+++ b/packages/backend/src/document/dto/portfolio-detail-response.dto.ts
@@ -1,10 +1,11 @@
 import { DocumentType } from '../entities/document.entity';
 
-export class ViewPortfolioResponseDto {
+export class PortfolioDetailResponseDto {
   documentId: string;
   type: DocumentType;
   portfolioId: string;
   title: string;
   content: string;
   createdAt: Date;
+  modifiedAt: Date;
 }

--- a/packages/backend/src/document/dto/update-portfolio-request.dto.ts
+++ b/packages/backend/src/document/dto/update-portfolio-request.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdatePortfolioRequestDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  content?: string;
+}


### PR DESCRIPTION
## 🎯 이슈 번호

- close #91 

## ✅ 완료 작업 목록

- [x] 포트폴리오 수정 요청 DTO (`UpdatePortfolioRequestDto`) 생성
- [x] 포트폴리오 수정 API (`PATCH /document/{documentId}/portfolio`) 컨트롤러 구현
- [x] 포트폴리오 수정 비즈니스 로직 (`updatePortfolio`) 서비스 구현
- [x] 포트폴리오 조회 응답 DTO (`PortfolioDetailResponseDto`)에 `modifiedAt` 필드 추가
- [x] API 동작 검증을 위한 테스트 스크립트 작성 및 실행 (`test-api.js`, `test-document-api.sh`)

---

## 💬 리뷰어에게

포트폴리오의 제목(`title`)과 내용(`content`)을 부분적으로 수정할 수 있는 기능을 구현했습니다.
기존 `PortfolioDetailResponseDto`에 `modifiedAt`이 누락되어 있어, 수정 시 반영 여부를 확인할 수 있도록 해당 필드를 추가했습니다.

테스트는 `packages/backend/test-document-api.sh` 스크립트를 통해 수행할 수 있습니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 부분 업데이트 (PATCH) 처리 방식 ]**

- **문제점**: 사용자가 제목만 수정하거나 내용만 수정하는 경우 등 다양한 입력에 유연하게 대응해야 했습니다.
- **해결 과정**:
    - DTO에서 `title`과 `content`를 모두 `optional`로 설정했습니다.
    - 서비스 로직에서 각 필드가 존재하는지 확인(`if (title) ...`)하여 존재하는 값만 엔티티에 업데이트하는 방식으로 구현했습니다.
    - 이를 통해 불필요한 데이터 덮어쓰기를 방지하고 유연성을 확보했습니다.

**[ 응답 일관성 유지 ]**

- **문제점**: 수정 후 클라이언트가 최신 수정 시간을 바로 알 수 있어야 UI에 반영하기 용이합니다.
- **해결 과정**: `PortfolioDetailResponseDto`에 `modifiedAt` 필드를 추가하고, 업데이트 응답 시에도 이 값을 포함하여 반환하도록 했습니다.

---

## 📸 스크린샷

### Curl 테스트 결과
<img width="2518" height="724" alt="image" src="https://github.com/user-attachments/assets/fbae1e08-f745-4cfc-85b6-9dd7d723d4c9" />



```text
[TEST 2-1] PATCH /document/:documentId/portfolio - Update Portfolio
Response: {"documentId":"16","type":"PORTFOLIO","portfolioId":"12","title":"Updated Portfolio Title","content":"Updated content with new information.","createdAt":"2026-01-26T07:17:16.943Z","modifiedAt":"2026-01-26T07:17:16.000Z"}
```
