### PR TITLE
[Feature] 사용자는 인터뷰를 삭제할 수 있다.

### DIFF
--- a/packages/backend/db/seeds.sql
+++ b/packages/backend/db/seeds.sql
@@ -21,100 +21,28 @@ INSERT INTO portfolios (portfolios_id, content, documents_id)
 VALUES (1, '개발 스킬/환경
 	•	Java: TDD, OOP, MVC 이해 및 적용 / 일급 컬렉션·Enum·record 활용 / 입력 검증·책임 분리 설계
 	•	Spring / Spring Boot: MSA 구조 설계, REST API, JPA, 트랜잭션 처리, JWT 인증 구현, WebSocket·SSE 등 실시간 통신 학습/적용
-	•	Kafka: Producer–Consumer 구조, Topic·Partition 구성 이해 / KRaft 모드 Kafka 클러스터 구축/운영 경험
 	•	Redis: Pub/Sub 기반 메시지 처리 / 싱글 스레드 구조 및 key-value 자료구조 이해·활용
-	•	기타: Python(Django/DRF), PostgreSQL·MongoDB, AWS(EC2/RDS/S3/Route53), Docker/Docker-Compose
-	•	협업 도구: GitHub, Figma, Notion, StarUML
-
-⸻
+	•	기타: PostgreSQL, AWS(EC2/RDS/S3/Route53), Docker/Docker-Compose
+	•	협업 도구: GitHub, Notion, StarUML
 
 프로젝트 요약
-
-1) SmileTogether (2025.01 ~ 2025.03)
-	•	역할: 팀장 + 백엔드 개발
-	•	목표: 팀 기반 협업용 메신저 플랫폼, 실시간 커뮤니케이션 + 대용량 트래픽 대응
-	•	구성/기여
-	•	MSA 기반 서버 아키텍처 및 DB 설계
-	•	유저(멤버)·이메일 서버 구현, 내부 서비스 간 HTTP 통신(RestTemplate)
-	•	WebSocket + STOMP 기반 채팅 기능 개발/고도화, 다중 채팅 서버로 연결 부하 분산
-	•	Kafka 메시지 브로커로 다중 채팅 서버 간 동기화
-	•	히스토리(메시지 보관) 서버 분리 후 Kafka 기반 채팅 데이터 CRUD 비동기 처리
-	•	채널 ID를 Key로 해싱해 동일 파티션 매핑 → 메시지 순서 보장
-	•	채팅 데이터 저장에 MongoDB(JSON 문서) 도입
-	•	STOMP 인바운드 채널 Interceptor로 디버깅 로그/연동
-	•	KRaft 모드 Kafka 클러스터(3 broker + 1 controller) 구성, Kafka UI 활용, Docker-Compose 기반 재현/운영
-	•	협업 방식/리딩
-	•	데일리 스크럼·코어타임 운영, 업무 분담 및 PMP 문서 작성, PR 알림 자동화 제안
-
-2) FaceFriend (2024.01 ~ 2024.05/06)
+1) AI 이미지 기반 소개팅 프로젝트 (2024.01 ~ 2024.05/06)
 	•	역할: 백엔드 개발
 	•	프로젝트 소개: AI 이미지 생성/관상 분석 기반의 데이팅 서비스(새로운 매칭 경험)
 	•	구성/기여
 	•	Spring + AWS(RDS/S3/EC2) 기반 서버 아키텍처 설계/구현
 	•	WebSocket + STOMP로 하트 요청/수락·거절 및 채팅 실시간 처리
-	•	Redis를 STOMP **외부 메시지 브로커(Pub/Sub)**로 활용
 	•	비연결(미접속) 상태 메시지 손실 대응: 사용자 앱 접속 정보 관리 → 접속 여부에 따라 송신/저장 분기, Redis에 저장/관리
 	•	채팅방 생성/조회/삭제, 메시지 조회 API 구현
 	•	Docker/Docker-Compose로 테스트 환경 구축, AWS 배포
 	•	StompHeaderAccessor + JWT Provider로 WebSocket(STOMP) 헤더 JWT 검증/정보 추출
 
-3) OneHabit (2024.03)
-	•	역할: 기획 및 백엔드 개발(포트폴리오 서술)
-	•	내용
-	•	습관 생성/조회/삭제/리스트 API
-	•	인증 시 경험치/성장 로직
-	•	하루 인증 3회 제한, 중복 인증 처리 방지
-	•	매일 자정 인증 데이터 초기화/연속 기록 초기화(스케줄러 활용)
-
-4) Moyeo (2023.07 ~ 2023.08, Django)
-	•	Swagger로 API 명세 자동화
-	•	모임 CRUD, 등급 자동 승급(크론 기반)
-	•	태그 기반 추천 API(필터링/제외 조건/종료일 고려/예외 시 랜덤)
-	•	태그 모델 통합 리팩토링
-
-5) Relanz (2023.06 ~ 2023.07, Django)
-	•	인증(회원/로그인/로그아웃)
-	•	태그 기반 추천, 아바타 커스터마이징, 스코어(랭킹)
-	•	Nginx + Gunicorn + EC2 배포
-
-6) KiKi_Kiosk (프로젝트 서술 포함)
+2) 키오스크 프로젝트 (프로젝트 서술 포함)
 	•	요구사항 분석 및 시스템 구조 설계
 	•	관리자 로그인/로그아웃 구현
 	•	비즈니스 로직 분리 및 유지보수 용이성 향상을 위한 설계 패턴 적용
 	•	GRASP 원칙 및 디자인 패턴(Controller/Creator/Expert/Singleton/DTO 등) 적용
 	•	AWS EC2 배포, Docker-Compose 기반 간단 배포 환경 구축
-
-⸻
-
-학습/대외활동/협업 경험
-	•	S사 Online Dev Camp (2024.10 ~ 2025.11): Java 백엔드 지원(포트폴리오 서술)
-	•	W사 부트캠프 프리코스 경험(포트폴리오 서술)
-	•	TDD/OOP/MVC 이해 증대 및 적용 시도
-	•	Spring 프레임워크 없이 Java만으로 과제 수행하며 Java 자체 학습
-	•	Stream/람다 등으로 코드 간결화, 읽기 쉬운 코드에 대한 학습
-	•	동아리/해커톤
-	•	웹 개발 및 IT 창업 동아리 활동(2023~2024)
-	•	교내/중앙 해커톤 참여(2023)
-	•	약 40명 규모 동아리 대표(2024)
-	•	동아리 연합 해커톤 중앙운영단 참여(2024)
-	•	G사 해커톤 2기 활동(2024) 및 약 300명 규모 해커톤 참여(벚꽃톤)
-
-⸻
-
-학력
-	•	OO대학교 한국역사학과 학사 (2019~2025) 졸업
-	•	OO대학교 소프트웨어전공 학사 (2022~2025) 복수학위 졸업
-
-⸻
-
-논문/수상
-	•	논문(2024-06-26, 한국정보과학회 학술발표논문집)
-	•	모바일 환경에서 JWT 토큰 관리로 사용자 개인정보 보안
-	•	재난 애플리케이션 특성을 고려한 토큰 발급/재발급 과정 서술
-	•	토큰 기반 시스템 백엔드 서버 구현 서술
-	•	수상
-	•	IT 연합 동아리 X OO대 해커톤 금상
-	•	2024 한국컴퓨터종합학술대회 학부생/주니어 논문경진대회 장려상
 ', 1);
 
 -- 5. AI Persona
@@ -328,3 +256,119 @@ VALUES (7, '기술 스택
 		- Prometheus + Grafana를 이용한 시스템 리소스(CPU, Memory) 및 애플리케이션 메트릭 시각화
 		- ELK Stack (Elasticsearch, Logstash, Kibana)을 이용한 중앙 집중형 로그 관리 시스템 구축
 ', 8);
+
+-- ==========================================
+-- Interview Data for User 2 (Java Backend)
+-- ==========================================
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id, score, feedback)
+VALUES (2, 'Java Backend Mock Interview', 'TECH', NOW(), 'LIKE', 1800000, 2, 'A', 'Java 메모리 관리와 Spring 트랜잭션에 대한 이해도가 높습니다.');
+
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (2, 'https://s3.aws.com/recordings/java-interview.mp4', '전반적으로 훌륭하나 JVM GC 튜닝 경험에 대한 구체적인 사례가 부족함.', 2);
+
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (3, NOW(), NOW(), 2, 3);
+
+INSERT INTO interviews_questions (question_id, content, created_at, modified_at, interview_id, persona_id)
+VALUES 
+(1, 'Java의 가비지 컬렉션(GC) 동작 원리에 대해 설명해주세요.', NOW(), NOW(), 2, 'p1'),
+(2, 'Spring Boot에서 @Transactional 어노테이션은 어떻게 동작하나요?', NOW(), NOW(), 2, 'p1'),
+(3, 'JPA N+1 문제는 무엇이며 어떻게 해결하셨나요?', NOW(), NOW(), 2, 'p1');
+
+INSERT INTO interviews_answers (answer_id, content, created_at, modified_at, interview_id)
+VALUES 
+(1, 'GC는 힙 영역의 객체 중 참조되지 않는 객체를 제거합니다. Young Generation과 Old Generation으로 나뉘며...', NOW(), NOW(), 2),
+(2, 'AOP 프록시 패턴을 사용하여 메서드 실행 전후에 트랜잭션을 시작하고 커밋/롤백합니다.', NOW(), NOW(), 2),
+(3, 'Fetch Join을 사용하거나 EntityGraph를 사용하여 연관된 엔티티를 한 번에 조회했습니다.', NOW(), NOW(), 2);
+
+
+-- ==========================================
+-- Interview Data for User 3 (Python Backend)
+-- ==========================================
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id, score, feedback)
+VALUES (3, 'Python Backend Interview', 'TECH', NOW(), 'NONE', 1500000, 3, 'B+', 'FastAPI 비동기 처리에 대한 설명이 인상적입니다.');
+
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (3, 'https://s3.aws.com/recordings/python-interview.mp4', 'Python GIL에 대한 심도 있는 이해가 필요함.', 3);
+
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (4, NOW(), NOW(), 3, 4);
+
+INSERT INTO interviews_questions (question_id, content, created_at, modified_at, interview_id, persona_id)
+VALUES 
+(4, 'Python의 GIL(Global Interpreter Lock)이 멀티스레딩에 미치는 영향은 무엇인가요?', NOW(), NOW(), 3, 'p1'),
+(5, 'FastAPI와 Django의 주요 차이점은 무엇이라고 생각하시나요?', NOW(), NOW(), 3, 'p1');
+
+INSERT INTO interviews_answers (answer_id, content, created_at, modified_at, interview_id)
+VALUES 
+(4, 'GIL 때문에 하나의 프로세스 내에서 동시에 하나의 스레드만 실행될 수 있어 CPU 바운드 작업에서 성능 제약이 있습니다.', NOW(), NOW(), 3),
+(5, 'Django는 풀스택 프레임워크로 많은 기능이 내장되어 있지만 무겁고, FastAPI는 비동기 지원이 강력하고 가볍습니다.', NOW(), NOW(), 3);
+
+
+-- ==========================================
+-- Interview Data for User 4 (React Frontend)
+-- ==========================================
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id, score, feedback)
+VALUES (4, 'Frontend React Interview', 'TECH', NOW(), 'LIKE', 2000000, 4, 'A-', 'React 렌더링 최적화 전략을 잘 이해하고 있습니다.');
+
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (4, 'https://s3.aws.com/recordings/react-interview.mp4', '상태 관리 라이브러리 선택 기준을 좀 더 명확히 하면 좋겠습니다.', 4);
+
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (5, NOW(), NOW(), 4, 5);
+
+INSERT INTO interviews_questions (question_id, content, created_at, modified_at, interview_id, persona_id)
+VALUES 
+(6, 'React의 useMemo와 useCallback의 차이점은 무엇인가요?', NOW(), NOW(), 4, 'p1'),
+(7, 'Next.js의 SSR과 CSR의 차이를 설명해주세요.', NOW(), NOW(), 4, 'p1');
+
+INSERT INTO interviews_answers (answer_id, content, created_at, modified_at, interview_id)
+VALUES 
+(6, 'useMemo는 값을 메모이제이션하고, useCallback은 함수 자체를 메모이제이션하여 불필요한 재생성을 방지합니다.', NOW(), NOW(), 4),
+(7, 'SSR은 서버에서 HTML을 생성해 보내주고 SEO에 유리하며, CSR은 클라이언트에서 JS로 렌더링하며 초기 로딩이 느릴 수 있습니다.', NOW(), NOW(), 4);
+
+
+-- ==========================================
+-- Interview Data for User 6 (Fullstack)
+-- ==========================================
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id, score, feedback)
+VALUES (5, 'Fullstack Node.js Interview', 'TECH', NOW(), 'NONE', 2400000, 6, 'S', '풀스택 개발자로서의 넓은 시야와 깊이 있는 지식을 겸비했습니다.');
+
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (5, 'https://s3.aws.com/recordings/fullstack-interview.mp4', '완벽합니다.', 5);
+
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (6, NOW(), NOW(), 5, 7);
+
+INSERT INTO interviews_questions (question_id, content, created_at, modified_at, interview_id, persona_id)
+VALUES 
+(8, 'Node.js의 이벤트 루프 동작 방식에 대해 설명해주세요.', NOW(), NOW(), 5, 'p1'),
+(9, 'Monorepo를 사용했을 때의 장단점은 무엇이었나요?', NOW(), NOW(), 5, 'p1');
+
+INSERT INTO interviews_answers (answer_id, content, created_at, modified_at, interview_id)
+VALUES 
+(8, '이벤트 루프는 싱글 스레드 기반으로 비동기 작업을 오프로딩하고 완료된 작업을 큐에서 가져와 처리합니다. 페이즈별로 동작하며...', NOW(), NOW(), 5),
+(9, '장점은 코드 재사용성과 의존성 관리가 쉽다는 것이고, 단점은 빌드 시간이 길어지고 도구 설정이 복잡할 수 있다는 점입니다.', NOW(), NOW(), 5);
+
+
+-- ==========================================
+-- Interview Data for User 7 (DevOps)
+-- ==========================================
+INSERT INTO interviews (interview_id, title, type, created_at, like_status, during_time, user_id, score, feedback)
+VALUES (6, 'DevOps Infrastructure Interview', 'TECH', NOW(), 'DISLIKE', 1200000, 7, 'C', 'Terraform 코드 구조화에 대한 고민이 더 필요해 보입니다.');
+
+INSERT INTO technical_interviews (technical_interviews_id, video_url, feedback_content, interview_id)
+VALUES (6, 'https://s3.aws.com/recordings/devops-interview.mp4', 'IaC 모듈화 전략에 대해 다시 학습하시기 바랍니다.', 6);
+
+INSERT INTO interviews_documents (interviews_documents_id, created_at, modified_at, technical_interview_id, documents_id)
+VALUES (7, NOW(), NOW(), 6, 8);
+
+INSERT INTO interviews_questions (question_id, content, created_at, modified_at, interview_id, persona_id)
+VALUES 
+(10, 'Kubernetes Pod와 Node의 관계를 설명해주세요.', NOW(), NOW(), 6, 'p1'),
+(11, 'CI/CD 파이프라인에서 Blue/Green 배포란 무엇인가요?', NOW(), NOW(), 6, 'p1');
+
+INSERT INTO interviews_answers (answer_id, content, created_at, modified_at, interview_id)
+VALUES 
+(10, 'Pod는 쿠버네티스의 가장 작은 배포 단위이며, Node는 이 Pod가 실행되는 워커 머신입니다.', NOW(), NOW(), 6),
+(11, '새로운 버전(Green)을 배포하고 트래픽을 한 번에 전환하여 다운타임을 최소화하는 전략입니다.', NOW(), NOW(), 6);

--- a/packages/backend/src/interview/entities/interview-answer.entity.ts
+++ b/packages/backend/src/interview/entities/interview-answer.entity.ts
@@ -27,7 +27,9 @@ export class InterviewAnswer {
   @UpdateDateColumn({ name: 'modified_at' })
   modifiedAt: Date;
 
-  @ManyToOne(() => Interview, (interview) => interview.answers)
+  @ManyToOne(() => Interview, (interview) => interview.answers, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'interview_id' })
   interview: Interview;
 }

--- a/packages/backend/src/interview/entities/interview-document.entity.ts
+++ b/packages/backend/src/interview/entities/interview-document.entity.ts
@@ -20,11 +20,13 @@ export class InterviewDocument {
   @UpdateDateColumn({ name: 'modified_at' })
   modifiedAt: Date;
 
-  @ManyToOne(() => TechnicalInterview, (tech) => tech.interviewDocuments)
+  @ManyToOne(() => TechnicalInterview, (tech) => tech.interviewDocuments, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'technical_interview_id' })
   technicalInterview: TechnicalInterview;
 
-  @ManyToOne(() => Document)
+  @ManyToOne(() => Document, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'documents_id' })
   document: Document;
 }

--- a/packages/backend/src/interview/entities/interview-question.entity.ts
+++ b/packages/backend/src/interview/entities/interview-question.entity.ts
@@ -24,7 +24,9 @@ export class InterviewQuestion {
   @UpdateDateColumn({ name: 'modified_at' })
   modifiedAt: Date;
 
-  @ManyToOne(() => Interview, (interview) => interview.questions)
+  @ManyToOne(() => Interview, (interview) => interview.questions, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'interview_id' })
   interview: Interview;
 

--- a/packages/backend/src/interview/entities/technical-interview.entity.ts
+++ b/packages/backend/src/interview/entities/technical-interview.entity.ts
@@ -20,7 +20,9 @@ export class TechnicalInterview {
   @Column({ name: 'feedback_content', type: 'varchar', length: 255 })
   feedbackContent: string;
 
-  @OneToOne(() => Interview, (interview) => interview.technical)
+  @OneToOne(() => Interview, (interview) => interview.technical, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'interview_id' })
   interview: Interview;
 

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -9,6 +9,8 @@ import {
   UploadedFile,
   UseInterceptors,
   Query,
+  Delete,
+  HttpCode,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { InterviewService } from './interview.service';
@@ -32,7 +34,7 @@ import { InterviewSummaryListResponse } from './dto/interview-summary.response.d
 @Controller('interview')
 export class InterviewController {
   private readonly logger = new Logger(InterviewController.name);
-  constructor(private readonly interviewService: InterviewService) { }
+  constructor(private readonly interviewService: InterviewService) {}
 
   @Post('tech/create')
   async createTechInterview(
@@ -156,5 +158,14 @@ export class InterviewController {
       type,
       sort,
     );
+  }
+
+  @Delete(':interviewId')
+  @HttpCode(204)
+  async deleteInterview(
+    @Param('interviewId') interviewId: string,
+  ): Promise<void> {
+    const userId = '1';
+    await this.interviewService.deleteInterview(userId, interviewId);
   }
 }

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -43,7 +43,7 @@ export class InterviewService {
     private readonly coverLetterRepository: CoverLetterRepository,
     private readonly documentRepository: DocumentRepository,
     private readonly interviewFeedBackService: InterviewFeedbackService,
-  ) { }
+  ) {}
 
   async calculateInterviewTime(
     userId: string,
@@ -299,6 +299,12 @@ export class InterviewService {
       score: interview.score,
       feedback: interview.feedback,
     };
+  }
+
+  async deleteInterview(userId: string, interviewId: string): Promise<void> {
+    const interview = await this.findExistingInterview(interviewId, ['user']);
+    interview.validateUser(userId);
+    await this.interviewRepository.remove(interview);
   }
 
   async listInterviews(


### PR DESCRIPTION
## 🎯 이슈 번호

- close #95 

## ✅ 완료 작업 목록

- [x] 인터뷰 삭제 API 구현 (`DELETE /interview/:interviewId`)
- [x] Child Entities (`InterviewQuestion`, `InterviewAnswer`, etc.)에 `onDelete: 'CASCADE'` 설정 추가
- [x] `InterviewService.deleteInterview` 메서드 구현 (Service 레벨 삭제 로직 제거 및 DB Cascade 활용)
- [x] `seeds.sql` 데이터 현실화 (User 2~7에 대한 실제 포트폴리오 및 면접 이력 데이터 추가)

---

## 💬 리뷰어에게

### 1. 인터뷰 삭제 구현 (`DELETE /interview/:interviewId`)
- **DB 레벨 Cascade**: 기존 TypeORM의 `cascade: true` 대신, `Interview`의 자식 엔티티(`Question`, `Answer`, `LiveCoding`, `Technical`)에 **`onDelete: 'CASCADE'`** 옵션을 적용했습니다. 이를 통해 `Interview` 엔티티만 삭제해도 연관된 데이터가 DB 제약 조건에 의해 깔끔하게 삭제되며, Service 계층의 비즈니스 로직을 단순화했습니다.

### 2. 테스트 데이터
- **`seeds.sql` 업데이트**: 기존 데모 데이터에 포함된 개인 식별 정보를 제거하고, 각 사용자(Java, Python, Frontend, DevOps 등)별 데이터 양을 균일하게 맞추어 정규화했습니다. 동시에 개발 및 테스트에 충분한 컨텍스트를 제공하도록 면접 이력 데이터를 보강했습니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 데이터 무결성 및 연쇄 삭제 전략 변경 ]**

- **문제점**: 인터뷰 삭제 시 `InterviewQuestion`, `InterviewAnswer` 등 하위 데이터가 남는 고아 객체 문제입니다. 초기에는 애플리케이션 레벨(`cascade: true`)에서 처리하려 했으나, 이는 삭제 전 모든 연광 관계를 `find`로 조회하여 메모리에 로드해야 하므로 불필요한 비용이 발생한다고 판단했습니다.
- **해결**: Entity 설정에서 외래 키 조건에 **`onDelete: 'CASCADE'`**를 명시하여, DB 엔진이 관계된 행을 자동으로 정리하도록 위임했습니다. 결과적으로 `deleteInterview` 메서드는 단순히 인터뷰 ID로 `remove`만 호출하면 되도록 최적화되었습니다.

---

## 📸 스크린샷

**테스트 curl 결과**
<img width="2238" height="1442" alt="image" src="https://github.com/user-attachments/assets/057f1963-fb7c-41f2-8f5b-dd6615bc00a8" />

```
[TEST 8] DELETE /interview/:id - Delete the new interview
Checking DB before deletion...
Q_Count: 1
A_Count: 1
✅ Delete successful (Status 204)

[TEST 8-1] Verify Cascaded Deletion in DB
Checking related tables for interview_id=8...
✅ Cascade Deletion Verified: Questions (0), Answers (0), Tech info (0) are all 0.

[TEST 9] GET /interview/1/time - Verify Interview 1 still exists
✅ Interview 1 is safe (Status 200)
```
