### PR TITLE
[Feature] 사용자는 구글 Oauth를 사용해 로그인 할 수 있다.

### DIFF
--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -1,4 +1,28 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
 
 @Controller('auth')
-export class AuthController {}
+export class AuthController {
+    private readonly googleClientId;
+    private readonly redirectUri;
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly authService: AuthService,
+    ) {
+        this.googleClientId = configService.getOrThrow('GOOGLE_CLIENT_ID');
+        this.redirectUri = configService.getOrThrow('OAUTH_REDIRECT_URI');
+    }
+
+    @Get('login/url/google')
+    getGoogleLoginUrl(): { url: string } {
+        const url = `https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${this.redirectUri}&client_id=${this.googleClientId}`;
+
+        return { url };
+    }
+
+    @Get('/signup/oauth')
+    async signup(@Query('code') code: string): Promise<any> {
+        return await this.authService.googleLogin(code);
+    }
+}

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -4,25 +4,25 @@ import { AuthService } from './auth.service';
 
 @Controller('auth')
 export class AuthController {
-    private readonly googleClientId;
-    private readonly redirectUri;
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly authService: AuthService,
-    ) {
-        this.googleClientId = configService.getOrThrow('GOOGLE_CLIENT_ID');
-        this.redirectUri = configService.getOrThrow('OAUTH_REDIRECT_URI');
-    }
+  private readonly googleClientId: string;
+  private readonly redirectUri: string;
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly authService: AuthService,
+  ) {
+    this.googleClientId = configService.getOrThrow<string>('GOOGLE_CLIENT_ID');
+    this.redirectUri = configService.getOrThrow<string>('OAUTH_REDIRECT_URI');
+  }
 
-    @Get('login/url/google')
-    getGoogleLoginUrl(): { url: string } {
-        const url = `https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${this.redirectUri}&client_id=${this.googleClientId}`;
+  @Get('login/url/google')
+  getGoogleLoginUrl(): { url: string } {
+    const url = `https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${this.redirectUri}&client_id=${this.googleClientId}`;
 
-        return { url };
-    }
+    return { url };
+  }
 
-    @Get('/signup/oauth')
-    async signup(@Query('code') code: string): Promise<any> {
-        return await this.authService.googleLogin(code);
-    }
+  @Get('/signup/oauth')
+  async signup(@Query('code') code: string): Promise<any> {
+    return await this.authService.googleLogin(code);
+  }
 }

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { UserModule } from '../user/user.module';
+import { GoogleOAuthService } from './google-oauth.service';
 
 @Module({
+  imports: [UserModule],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, GoogleOAuthService],
 })
-export class AuthModule {}
+export class AuthModule { }

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -9,4 +9,4 @@ import { GoogleOAuthService } from './google-oauth.service';
   controllers: [AuthController],
   providers: [AuthService, GoogleOAuthService],
 })
-export class AuthModule { }
+export class AuthModule {}

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -1,4 +1,34 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { UserService } from '../user/user.service';
+import { GoogleOAuthService } from './google-oauth.service';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+    private readonly logger = new Logger(AuthService.name);
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly userService: UserService,
+        private readonly googleOAuthService: GoogleOAuthService,
+    ) { }
+
+    async googleLogin(code: string): Promise<any> {
+        const accessToken =
+            await this.googleOAuthService.exchangeCodeForToken(code);
+        const userData = await this.googleOAuthService.getUserInfo(accessToken);
+
+        const email = userData.email;
+        const profileUrl = userData.picture;
+        const sub = userData.id;
+
+        // 기존에 회원이 존재하는지 찾는다.
+        let user = await this.userService.findOneBySub(sub);
+
+        // 신규 회원이라면 회원 정보를 DB에 등록한다.
+        if (!user) {
+            user = await this.userService.registerUser(email, profileUrl, sub);
+        }
+
+        return user;
+    }
+}

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -5,30 +5,30 @@ import { GoogleOAuthService } from './google-oauth.service';
 
 @Injectable()
 export class AuthService {
-    private readonly logger = new Logger(AuthService.name);
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly userService: UserService,
-        private readonly googleOAuthService: GoogleOAuthService,
-    ) { }
+  private readonly logger = new Logger(AuthService.name);
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly userService: UserService,
+    private readonly googleOAuthService: GoogleOAuthService,
+  ) {}
 
-    async googleLogin(code: string): Promise<any> {
-        const accessToken =
-            await this.googleOAuthService.exchangeCodeForToken(code);
-        const userData = await this.googleOAuthService.getUserInfo(accessToken);
+  async googleLogin(code: string): Promise<any> {
+    const accessToken =
+      await this.googleOAuthService.exchangeCodeForToken(code);
+    const userData = await this.googleOAuthService.getUserInfo(accessToken);
 
-        const email = userData.email;
-        const profileUrl = userData.picture;
-        const sub = userData.id;
+    const email = userData.email;
+    const profileUrl = userData.profileUrl;
+    const sub = userData.sub;
 
-        // 기존에 회원이 존재하는지 찾는다.
-        let user = await this.userService.findOneBySub(sub);
+    // 기존에 회원이 존재하는지 찾는다.
+    let user = await this.userService.findOneBySub(sub);
 
-        // 신규 회원이라면 회원 정보를 DB에 등록한다.
-        if (!user) {
-            user = await this.userService.registerUser(email, profileUrl, sub);
-        }
-
-        return user;
+    // 신규 회원이라면 회원 정보를 DB에 등록한다.
+    if (!user) {
+      user = await this.userService.registerUser(email, profileUrl, sub);
     }
+
+    return user;
+  }
 }

--- a/packages/backend/src/auth/google-oauth.service.ts
+++ b/packages/backend/src/auth/google-oauth.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class GoogleOAuthService {
+    private readonly logger = new Logger(GoogleOAuthService.name);
+    private readonly googleClientId: string;
+    private readonly googleClientSecret: string;
+    private readonly redirectUri: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.googleClientId =
+            this.configService.getOrThrow<string>('GOOGLE_CLIENT_ID');
+        this.googleClientSecret = this.configService.getOrThrow<string>(
+            'GOOGLE_CLIENT_SECRET',
+        );
+        this.redirectUri =
+            this.configService.getOrThrow<string>('OAUTH_REDIRECT_URI');
+    }
+
+    async exchangeCodeForToken(code: string): Promise<string> {
+        const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                code,
+                client_id: this.googleClientId,
+                client_secret: this.googleClientSecret,
+                redirect_uri: this.redirectUri,
+                grant_type: 'authorization_code',
+            }),
+        });
+
+        if (!tokenResponse.ok) {
+            this.logger.error('code <-> 애세스 토큰 교환에 실패했습니다.');
+            throw new InternalServerErrorException('Failed to get access token');
+        }
+
+        const tokenData = await tokenResponse.json();
+        return tokenData.access_token;
+    }
+
+    async getUserInfo(accessToken: string): Promise<any> {
+        const userResponse = await fetch(
+            'https://www.googleapis.com/oauth2/v2/userinfo',
+            {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            },
+        );
+
+        if (!userResponse.ok) {
+            this.logger.error('사용자 정보를 가져오는데 실패했습니다.');
+            throw new InternalServerErrorException('Failed to get user info');
+        }
+
+        return await userResponse.json();
+    }
+}

--- a/packages/backend/src/auth/google-oauth.service.ts
+++ b/packages/backend/src/auth/google-oauth.service.ts
@@ -72,27 +72,36 @@ export class GoogleOAuthService {
   }
 
   async getUserInfo(accessToken: string): Promise<GoogleUser> {
-    const userResponse = await fetch(
-      'https://www.googleapis.com/oauth2/v2/userinfo',
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
+    try {
+      const userResponse = await fetch(
+        'https://www.googleapis.com/oauth2/v2/userinfo',
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         },
-      },
-    );
+      );
 
-    if (!userResponse.ok) {
-      this.logger.error('사용자 정보를 가져오는데 실패했습니다.');
-      throw new InternalServerErrorException('Failed to get user info');
+      if (!userResponse.ok) {
+        this.logger.error('사용자 정보를 가져오는데 실패했습니다.');
+        throw new InternalServerErrorException(
+          '구글 사용자 정보를 가져오는데 실패했습니다.',
+        );
+      }
+
+      const userResponseJson =
+        (await userResponse.json()) as GoogleUserResponse;
+
+      return {
+        profileUrl: userResponseJson.picture,
+        email: userResponseJson.email,
+        sub: userResponseJson.id,
+      };
+    } catch (err) {
+      // 👈 여기서 네트워크 에러, 타임아웃 등 잡힘
+      this.logger.error('Google userinfo network error', err);
+      throw new InternalServerErrorException('구글 OAuth 연결에 실패했습니다.');
     }
-
-    const userResponseJson = (await userResponse.json()) as GoogleUserResponse;
-
-    return {
-      profileUrl: userResponseJson.picture,
-      email: userResponseJson.email,
-      sub: userResponseJson.id,
-    };
   }
 }

--- a/packages/backend/src/auth/google-oauth.service.ts
+++ b/packages/backend/src/auth/google-oauth.service.ts
@@ -1,63 +1,98 @@
-import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+
+interface GoogleUserResponse {
+  id: string;
+  email: string;
+  verified_email: boolean;
+  name: string;
+  given_name: string;
+  family_name: string;
+  picture: string;
+  locale: string;
+}
+
+export type GoogleUser = {
+  email: string;
+  profileUrl: string;
+  sub: string;
+};
+
+interface GoogleTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+  refresh_token?: string;
+}
 
 @Injectable()
 export class GoogleOAuthService {
-    private readonly logger = new Logger(GoogleOAuthService.name);
-    private readonly googleClientId: string;
-    private readonly googleClientSecret: string;
-    private readonly redirectUri: string;
+  private readonly logger = new Logger(GoogleOAuthService.name);
+  private readonly googleClientId: string;
+  private readonly googleClientSecret: string;
+  private readonly redirectUri: string;
 
-    constructor(private readonly configService: ConfigService) {
-        this.googleClientId =
-            this.configService.getOrThrow<string>('GOOGLE_CLIENT_ID');
-        this.googleClientSecret = this.configService.getOrThrow<string>(
-            'GOOGLE_CLIENT_SECRET',
-        );
-        this.redirectUri =
-            this.configService.getOrThrow<string>('OAUTH_REDIRECT_URI');
+  constructor(private readonly configService: ConfigService) {
+    this.googleClientId =
+      this.configService.getOrThrow<string>('GOOGLE_CLIENT_ID');
+    this.googleClientSecret = this.configService.getOrThrow<string>(
+      'GOOGLE_CLIENT_SECRET',
+    );
+    this.redirectUri =
+      this.configService.getOrThrow<string>('OAUTH_REDIRECT_URI');
+  }
+
+  async exchangeCodeForToken(code: string): Promise<string> {
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        code,
+        client_id: this.googleClientId,
+        client_secret: this.googleClientSecret,
+        redirect_uri: this.redirectUri,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      this.logger.error('code <-> 애세스 토큰 교환에 실패했습니다.');
+      throw new InternalServerErrorException('Failed to get access token');
     }
 
-    async exchangeCodeForToken(code: string): Promise<string> {
-        const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: new URLSearchParams({
-                code,
-                client_id: this.googleClientId,
-                client_secret: this.googleClientSecret,
-                redirect_uri: this.redirectUri,
-                grant_type: 'authorization_code',
-            }),
-        });
+    const tokenData = (await tokenResponse.json()) as GoogleTokenResponse;
+    return tokenData.access_token;
+  }
 
-        if (!tokenResponse.ok) {
-            this.logger.error('code <-> 애세스 토큰 교환에 실패했습니다.');
-            throw new InternalServerErrorException('Failed to get access token');
-        }
+  async getUserInfo(accessToken: string): Promise<GoogleUser> {
+    const userResponse = await fetch(
+      'https://www.googleapis.com/oauth2/v2/userinfo',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
 
-        const tokenData = await tokenResponse.json();
-        return tokenData.access_token;
+    if (!userResponse.ok) {
+      this.logger.error('사용자 정보를 가져오는데 실패했습니다.');
+      throw new InternalServerErrorException('Failed to get user info');
     }
 
-    async getUserInfo(accessToken: string): Promise<any> {
-        const userResponse = await fetch(
-            'https://www.googleapis.com/oauth2/v2/userinfo',
-            {
-                method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            },
-        );
+    const userResponseJson = (await userResponse.json()) as GoogleUserResponse;
 
-        if (!userResponse.ok) {
-            this.logger.error('사용자 정보를 가져오는데 실패했습니다.');
-            throw new InternalServerErrorException('Failed to get user info');
-        }
-
-        return await userResponse.json();
-    }
+    return {
+      profileUrl: userResponseJson.picture,
+      email: userResponseJson.email,
+      sub: userResponseJson.id,
+    };
+  }
 }

--- a/packages/backend/src/interview/dto/interview-summary.request.dto.ts
+++ b/packages/backend/src/interview/dto/interview-summary.request.dto.ts
@@ -2,26 +2,26 @@ import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
 import { InterviewType } from '../entities/interview.entity';
 
 export enum SortType {
-    DESC = 'DESC',
-    ASC = 'ASC',
+  DESC = 'DESC',
+  ASC = 'ASC',
 }
 
 export class InterviewSummaryRequest {
-    @IsNumber()
-    @Min(0)
-    @IsOptional()
-    page: number = 0;
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  page: number = 0;
 
-    @IsNumber()
-    @Min(1)
-    @IsOptional()
-    take: number = 6;
+  @IsNumber()
+  @Min(1)
+  @IsOptional()
+  take: number = 6;
 
-    @IsEnum(InterviewType)
-    @IsOptional()
-    type?: InterviewType;
+  @IsEnum(InterviewType)
+  @IsOptional()
+  type?: InterviewType;
 
-    @IsEnum(SortType)
-    @IsOptional()
-    sort: SortType = SortType.DESC;
+  @IsEnum(SortType)
+  @IsOptional()
+  sort: SortType = SortType.DESC;
 }

--- a/packages/backend/src/interview/dto/interview-summary.response.dto.ts
+++ b/packages/backend/src/interview/dto/interview-summary.response.dto.ts
@@ -1,13 +1,13 @@
 import { InterviewType } from '../entities/interview.entity';
 
 export class InterviewSummaryListResponse {
-    interviews: InterviewSummaryResponse[];
-    totalPage: number;
+  interviews: InterviewSummaryResponse[];
+  totalPage: number;
 }
 
 export class InterviewSummaryResponse {
-    interviewId: string;
-    title: string;
-    type: InterviewType;
-    createdAt: Date;
+  interviewId: string;
+  title: string;
+  type: InterviewType;
+  createdAt: Date;
 }

--- a/packages/backend/src/interview/interview.controller.ts
+++ b/packages/backend/src/interview/interview.controller.ts
@@ -32,7 +32,7 @@ import { InterviewSummaryListResponse } from './dto/interview-summary.response.d
 @Controller('interview')
 export class InterviewController {
   private readonly logger = new Logger(InterviewController.name);
-  constructor(private readonly interviewService: InterviewService) { }
+  constructor(private readonly interviewService: InterviewService) {}
 
   @Post('tech/create')
   async createTechInterview(

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -43,7 +43,7 @@ export class InterviewService {
     private readonly coverLetterRepository: CoverLetterRepository,
     private readonly documentRepository: DocumentRepository,
     private readonly interviewFeedBackService: InterviewFeedbackService,
-  ) { }
+  ) {}
 
   async calculateInterviewTime(
     userId: string,

--- a/packages/backend/src/user/entities/user.entity.ts
+++ b/packages/backend/src/user/entities/user.entity.ts
@@ -17,6 +17,9 @@ export class User {
   @Column({ name: 'user_email', type: 'varchar', length: 255 })
   userEmail: string;
 
+  @Column({ name: 'sub', type: 'varchar', length: 255, nullable: true })
+  sub: string;
+
   @Column({ name: 'profile_url', type: 'varchar', length: 255, nullable: true })
   profileUrl: string;
 

--- a/packages/backend/src/user/user.module.ts
+++ b/packages/backend/src/user/user.module.ts
@@ -6,6 +6,6 @@ import { UserRepository } from './user.repository';
 @Module({
   controllers: [UserController],
   providers: [UserService, UserRepository],
-  exports: [UserService],
+  exports: [UserService, UserRepository],
 })
-export class UserModule {}
+export class UserModule { }

--- a/packages/backend/src/user/user.module.ts
+++ b/packages/backend/src/user/user.module.ts
@@ -8,4 +8,4 @@ import { UserRepository } from './user.repository';
   providers: [UserService, UserRepository],
   exports: [UserService, UserRepository],
 })
-export class UserModule { }
+export class UserModule {}

--- a/packages/backend/src/user/user.repository.ts
+++ b/packages/backend/src/user/user.repository.ts
@@ -15,5 +15,4 @@ export class UserRepository extends Repository<User> {
   async findBySub(sub: string): Promise<User | null> {
     return this.findOne({ where: { sub: sub } });
   }
-
 }

--- a/packages/backend/src/user/user.repository.ts
+++ b/packages/backend/src/user/user.repository.ts
@@ -11,4 +11,9 @@ export class UserRepository extends Repository<User> {
   async findById(userId: string): Promise<User | null> {
     return this.findOne({ where: { userId: userId } });
   }
+
+  async findBySub(sub: string): Promise<User | null> {
+    return this.findOne({ where: { sub: sub } });
+  }
+
 }

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -6,7 +6,7 @@ import { UserRepository } from './user.repository';
 export class UserService {
   private readonly logger = new Logger('UserService');
 
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(private readonly userRepository: UserRepository) { }
 
   async findExistingUser(userId: string): Promise<User> {
     const user = await this.userRepository.findById(userId);
@@ -15,5 +15,21 @@ export class UserService {
       throw new NotFoundException('존재하지않는 사용자입니다.');
     }
     return user;
+  }
+
+  async findOneBySub(sub: string): Promise<User | null> {
+    return await this.userRepository.findBySub(sub);
+  }
+
+  async registerUser(
+    email: string,
+    profileUrl: string,
+    sub: string,
+  ): Promise<User> {
+    const user = new User();
+    user.userEmail = email;
+    user.profileUrl = profileUrl;
+    user.sub = sub;
+    return await this.userRepository.save(user);
   }
 }

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -6,7 +6,7 @@ import { UserRepository } from './user.repository';
 export class UserService {
   private readonly logger = new Logger('UserService');
 
-  constructor(private readonly userRepository: UserRepository) { }
+  constructor(private readonly userRepository: UserRepository) {}
 
   async findExistingUser(userId: string): Promise<User> {
     const user = await this.userRepository.findById(userId);


### PR DESCRIPTION
## 🎯 이슈 번호

- close #99

## ✅ 완료 작업 목록

- [x] 구글 로그인 폼 URL 발급 API (`GET /auth/login/url/google`) 구현
- [x] 구글 로그인 콜백 및 회원가입/로그인 처리 API (`GET /auth/signup/oauth`) 구현
- [x] `GoogleOAuthService` 구현 (액세스 토큰 교환 및 사용자 정보 조회)
- [x] User 엔티티에 `sub` (구글 고유 ID) 필드 추가 및 `UserService` 로직 수정

---

## 💬 리뷰어에게

- `AuthController`에 구글 로그인 URL을 반환하는 엔드포인트와 리다이렉트 콜백을 처리하는 엔드포인트를 추가했습니다.
- `GoogleOAuthService`를 파일을 생성하여 구글 OAuth 2.0 API와의 통신을 담당하도록 했습니다.
- `AuthService.googleLogin` 메서드에서 사용자 `sub` 값을 기준으로 **기존 회원이면 로그인 처리를, 신규 회원이면 회원가입 처리**를 수행하도록 로직을 구현했습니다.
- `User` 엔티티에 소셜 로그인 식별을 위한 `sub` 컬럼이 추가되었습니다.

> 
---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 로그인 폼 URL 발급 받기 ]**

- **문제점**: OAuth 인증을 위한 구글 로그인 폼의 주소를 프론트에게 어떻게 줄지 고민했습니다.
- **해결 과정**: 기존의 react를 이용한 프론트였다면 서버에서 302 리다이렉트를 주소로 해줬을 것이지만, 현재 구조에선 vercel이 백엔드 api 요청을 대신하므로 302 리다이렉트 없이 url 응답값만을 주었습니다.

**[ 회원가입의 HTTP Method ]**

- **문제점**: 구글 로그인(회원가입)의 HTTP Method를 post, get 중 무엇으로 할 지 고민했습니다.
- **해결 과정**: 백엔드 로컬 환경에서 구글 로그인을 테스트 하기 위해선 브라우저의 리다이렉션을 이용하므로 백엔드는 google code를 GET으로 받을 수 밖에 없습니다. 하지만, 운영, 개발 서버 환경에선 Next.js를 사용합니다. 그래서, Post 요청으로 회원가입을 진행하는 것이 더 바람직하다고 느껴서 두 메서드중 무엇을 선택해야 할 지 고민했습니다. 결론적으로 GET Method를 선택했습니다. POST를 선택한다면 백엔드 로컬 환경에서 구글 로그인이 잘 되는지 테스트를 할 수 없다는 것이 주 요인이였습니다. Next.js의 경우 Get, Post 어떤 요청이든 보낼 수 있기 떄문에 로컬 개발 환경을 더 고려하여 GET Method를 선택했습니다. 
