### PR TITLE
[Feature] 문서 관리 페이지 구현

### DIFF
--- a/packages/frontend/app/(tabs)/(simulator)/components/document-card.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/components/document-card.tsx
@@ -20,6 +20,7 @@ interface DocumentCardProps {
   isSelected?: boolean;
   onSelect?: (id: string) => void;
   isSelectable?: boolean;
+  showDeleteAction?: boolean;
 }
 
 export function DocumentCard({
@@ -27,6 +28,7 @@ export function DocumentCard({
   isSelected,
   onSelect,
   isSelectable = true,
+  showDeleteAction = false,
 }: DocumentCardProps) {
   const canClick = isSelectable && !!onSelect;
 
@@ -67,7 +69,7 @@ export function DocumentCard({
             </div>
           </div>
           <AnimatePresence>
-            {isSelectable && isSelected && (
+            {showDeleteAction && isSelectable && isSelected && (
               <motion.div
                 initial={{ opacity: 0, scale: 0.5 }}
                 animate={{ opacity: 1, scale: 1 }}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
@@ -27,6 +27,8 @@ export async function getFeedback({
   return (await res.json()) as IFeedback;
 }
 
+// 현재 사용하고 있지 않아 lint 에러가 나긴 하나, 나중에 추가될 것 같아서 놔둡니다.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function startFeedback({ interviewId }: { interviewId?: string }) {
   if (process.env.NODE_ENV === "development") {
     await new Promise((r) => setTimeout(r, 200));

--- a/packages/frontend/app/(tabs)/(simulator)/interview/components/video-grid.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/components/video-grid.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import clsx from "clsx";
 
 import VideoTile from "./video-tile";

--- a/packages/frontend/app/(tabs)/(simulator)/interview/components/video-tile.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/components/video-tile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Ghost } from "lucide-react";
 
 import { cn } from "@/app/lib/utils";

--- a/packages/frontend/app/(tabs)/(simulator)/interview/create/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/create/page.tsx
@@ -12,8 +12,10 @@ import { createInterviewClient } from "@/app/lib/client/interview";
 import {
   DocumentCard,
   type DocType,
+  type DocumentItem,
 } from "@/app/(tabs)/(simulator)/components/document-card";
 import { useDocuments } from "@/app/hooks/use-documents";
+import DocumentCreateModal from "@/app/(tabs)/documents/components/document-create-modal";
 
 type InterviewMode = "live" | "tech";
 
@@ -26,11 +28,12 @@ export default function InterviewCreatePage() {
   const router = useRouter();
 
   const userId = "1";
-  const { documents, isLoading } = useDocuments(userId);
+  const { documents, isLoading, addDocument } = useDocuments(userId);
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [title, setTitle] = useState<string>("");
   const [mode, setMode] = useState<InterviewMode>("tech");
+  const [isDocModalOpen, setIsDocModalOpen] = useState<boolean>(false);
 
   const [selectedDocs, setSelectedDocs] = useState<SelectedDocs>({
     COVER_LETTER: null,
@@ -167,7 +170,7 @@ export default function InterviewCreatePage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => alert("미구현 기능입니다.")}
+              onClick={() => setIsDocModalOpen(true)}
               className="h-9 gap-2 rounded-lg border-dashed border-muted-foreground/50 text-xs text-muted-foreground transition-all hover:border-primary hover:text-primary"
             >
               <Plus className="h-4 w-4" />새 서류 업로드
@@ -214,6 +217,15 @@ export default function InterviewCreatePage() {
           </Button>
         </footer>
       </div>
+
+      <DocumentCreateModal
+        open={isDocModalOpen}
+        onClose={() => setIsDocModalOpen(false)}
+        onCreate={(newDocument: DocumentItem) => {
+          addDocument(newDocument);
+          setIsDocModalOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/packages/frontend/app/(tabs)/documents/components/document-create-modal.tsx
+++ b/packages/frontend/app/(tabs)/documents/components/document-create-modal.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import React, { useState } from "react";
+import { DocumentItem } from "@/app/(tabs)/(simulator)/components/document-card";
+import {
+  createCoverLetter,
+  createPortfolio,
+} from "../../../lib/client/document";
+import { Button } from "@/app/components/ui/button";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (document: DocumentItem) => void;
+}
+
+interface QuestionAnswer {
+  question: string;
+  answer: string;
+}
+
+export default function DocumentCreateModal({
+  open,
+  onClose,
+  onCreate,
+}: Props) {
+  const [documentType, setDocumentType] = useState<
+    "COVER_LETTER" | "PORTFOLIO"
+  >("COVER_LETTER");
+  const [title, setTitle] = useState("");
+  const [questionAnswerList, setQuestionAnswerList] = useState<
+    QuestionAnswer[]
+  >([{ question: "", answer: "" }]);
+  const [portfolioContent, setPortfolioContent] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  if (!open) return null;
+
+  function updateQuestionAnswer(
+    targetIndex: number,
+    field: keyof QuestionAnswer,
+    value: string,
+  ) {
+    setQuestionAnswerList((previousList) => {
+      const newList = [...previousList];
+      newList[targetIndex] = { ...newList[targetIndex], [field]: value };
+      return newList;
+    });
+  }
+
+  function addQuestionAnswer() {
+    setQuestionAnswerList((previousList) => [
+      ...previousList,
+      { question: "", answer: "" },
+    ]);
+  }
+
+  function removeQuestionAnswer(targetIndex: number) {
+    setQuestionAnswerList((previousList) =>
+      previousList.filter((_, index) => index !== targetIndex),
+    );
+  }
+
+  async function handleSubmit(event?: React.FormEvent) {
+    event?.preventDefault();
+    setIsLoading(true);
+
+    try {
+      let createdDocument: DocumentItem;
+      if (documentType === "COVER_LETTER") {
+        createdDocument = await createCoverLetter({
+          title,
+          qa: questionAnswerList,
+        });
+      } else {
+        createdDocument = await createPortfolio({
+          title,
+          content: portfolioContent,
+        });
+      }
+      onCreate(createdDocument);
+      onClose();
+    } catch (error) {
+      console.error("Document creation failed:", error);
+      alert("문서 생성에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <form
+        className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-lg"
+        onSubmit={handleSubmit}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-bold">새 서류 등록</h3>
+          <div className="flex gap-2">
+            <Button
+              variant={documentType === "COVER_LETTER" ? "default" : "ghost"}
+              onClick={() => setDocumentType("COVER_LETTER")}
+              type="button"
+            >
+              커버레터
+            </Button>
+            <Button
+              variant={documentType === "PORTFOLIO" ? "default" : "ghost"}
+              onClick={() => setDocumentType("PORTFOLIO")}
+              type="button"
+            >
+              포트폴리오
+            </Button>
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700">
+            제목
+          </label>
+          <input
+            className="mt-1 w-full rounded border px-3 py-2"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            required
+          />
+        </div>
+
+        {documentType === "COVER_LETTER" ? (
+          <div className="space-y-3">
+            {questionAnswerList.map((item, index) => (
+              <div key={index} className="flex gap-2">
+                <input
+                  placeholder={`질문 ${index + 1}`}
+                  className="flex-1 rounded border px-2 py-1"
+                  value={item.question}
+                  onChange={(event) =>
+                    updateQuestionAnswer(index, "question", event.target.value)
+                  }
+                  required
+                />
+                <input
+                  placeholder={`답변 ${index + 1}`}
+                  className="flex-1 rounded border px-2 py-1"
+                  value={item.answer}
+                  onChange={(event) =>
+                    updateQuestionAnswer(index, "answer", event.target.value)
+                  }
+                  required
+                />
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={() => removeQuestionAnswer(index)}
+                >
+                  삭제
+                </Button>
+              </div>
+            ))}
+            <Button type="button" onClick={addQuestionAnswer}>
+              질문 추가
+            </Button>
+          </div>
+        ) : (
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">
+              포트폴리오 내용
+            </label>
+            <textarea
+              className="mt-1 h-48 w-full rounded border px-3 py-2"
+              value={portfolioContent}
+              onChange={(event) => setPortfolioContent(event.target.value)}
+              required
+            />
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="ghost" type="button" onClick={onClose}>
+            취소
+          </Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? "생성중..." : "생성"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/documents/components/documents-client.tsx
+++ b/packages/frontend/app/(tabs)/documents/components/documents-client.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/app/components/ui/button";
+import { Trash, Plus } from "lucide-react";
+import {
+  DocumentCard,
+  DocumentItem,
+} from "@/app/(tabs)/(simulator)/components/document-card";
+import DocumentCreateModal from "./document-create-modal";
+import { deleteDocumentsClientSideBulk } from "../../../lib/client/document";
+
+interface Props {
+  initialDocuments: DocumentItem[];
+}
+
+export default function DocumentsClient({ initialDocuments }: Props) {
+  const router = useRouter();
+  const [documents, setDocuments] = useState<DocumentItem[]>(
+    initialDocuments || [],
+  );
+  const [selectedDocumentIds, setSelectedDocumentIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const allDocumentIds = useMemo(
+    () => documents.map((document) => document.documentId),
+    [documents],
+  );
+
+  const isAllSelected = useMemo(
+    () =>
+      allDocumentIds.length > 0 &&
+      allDocumentIds.every((id) => selectedDocumentIds.has(id)),
+    [allDocumentIds, selectedDocumentIds],
+  );
+
+  function toggleDocumentSelection(documentId: string) {
+    setSelectedDocumentIds((previousIds) => {
+      const nextIds = new Set(previousIds);
+      if (nextIds.has(documentId)) {
+        nextIds.delete(documentId);
+      } else {
+        nextIds.add(documentId);
+      }
+      return nextIds;
+    });
+  }
+
+  function toggleSelectAllVisible() {
+    setSelectedDocumentIds((previousIds) => {
+      const nextIds = new Set(previousIds);
+      if (isAllSelected) {
+        allDocumentIds.forEach((id) => nextIds.delete(id));
+      } else {
+        allDocumentIds.forEach((id) => nextIds.add(id));
+      }
+      return nextIds;
+    });
+  }
+
+  async function handleDeleteDocuments() {
+    if (selectedDocumentIds.size === 0) return;
+
+    const shouldProceed = window.confirm(
+      `${selectedDocumentIds.size}개의 서류를 삭제하시겠습니까?`,
+    );
+    if (!shouldProceed) return;
+
+    setIsLoading(true);
+    try {
+      const documentMap: Record<string, DocumentItem> = {};
+      documents.forEach(
+        (document) => (documentMap[document.documentId] = document),
+      );
+
+      const targetIds = Array.from(selectedDocumentIds);
+      const { successIds, failedIds } = await deleteDocumentsClientSideBulk(
+        targetIds,
+        documentMap,
+      );
+
+      if (successIds.length > 0) {
+        setDocuments((previousDocuments) =>
+          previousDocuments.filter(
+            (document) => !successIds.includes(document.documentId),
+          ),
+        );
+      }
+
+      setSelectedDocumentIds((previousIds) => {
+        const nextIds = new Set(previousIds);
+        successIds.forEach((id) => nextIds.delete(id));
+        return nextIds;
+      });
+
+      if (failedIds.length > 0) {
+        alert(`${failedIds.length}개 항목 삭제에 실패했습니다.`);
+      }
+
+      router.refresh();
+    } catch (error) {
+      console.error("Bulk deletion failed:", error);
+      alert("삭제 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold">Documents</h2>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={toggleSelectAllVisible}>
+            {isAllSelected ? "Unselect all" : "Select all"}
+          </Button>
+
+          {selectedDocumentIds.size > 0 ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDeleteDocuments}
+              disabled={isLoading}
+            >
+              <Trash className="mr-2 h-4 w-4" /> 삭제
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => setIsModalOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" /> 새 서류 등록
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {documents.map((document: DocumentItem) => (
+          <DocumentCard
+            key={document.documentId}
+            doc={document}
+            isSelected={selectedDocumentIds.has(document.documentId)}
+            onSelect={toggleDocumentSelection}
+            isSelectable={true}
+            showDeleteAction={true}
+          />
+        ))}
+      </div>
+
+      <DocumentCreateModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onCreate={(newDocument: DocumentItem) => {
+          setDocuments((previousDocuments) => [
+            newDocument,
+            ...previousDocuments,
+          ]);
+          setIsModalOpen(false);
+          router.refresh();
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/documents/components/documents-client.tsx
+++ b/packages/frontend/app/(tabs)/documents/components/documents-client.tsx
@@ -111,14 +111,15 @@ export default function DocumentsClient({ initialDocuments }: Props) {
   }
 
   return (
-    <div>
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold">Documents</h2>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={toggleSelectAllVisible}>
-            {isAllSelected ? "Unselect all" : "Select all"}
+            {isAllSelected ? "전체 해제" : "전체 선택"}
           </Button>
+        </div>
 
+        <div className="flex items-center gap-2">
           {selectedDocumentIds.size > 0 ? (
             <Button
               variant="destructive"
@@ -136,7 +137,7 @@ export default function DocumentsClient({ initialDocuments }: Props) {
         </div>
       </div>
 
-      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {documents.map((document: DocumentItem) => (
           <DocumentCard
             key={document.documentId}

--- a/packages/frontend/app/(tabs)/documents/components/documents-header.tsx
+++ b/packages/frontend/app/(tabs)/documents/components/documents-header.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/app/components/ui/button";
+import { Trash, Plus } from "lucide-react";
+
+interface Props {
+  selectedCount: number;
+  onOpenCreate: () => void;
+  onDeleteClick: () => void;
+}
+
+export default function DocumentsHeader({
+  selectedCount,
+  onOpenCreate,
+  onDeleteClick,
+}: Props) {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="text-lg font-bold">Documents</h2>
+      <div className="flex items-center gap-2">
+        {selectedCount > 0 ? (
+          <Button variant="destructive" size="sm" onClick={onDeleteClick}>
+            <Trash className="mr-2" /> 삭제
+          </Button>
+        ) : (
+          <Button size="sm" onClick={onOpenCreate}>
+            <Plus className="mr-2" /> 새 서류 등록
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/documents/layout.tsx
+++ b/packages/frontend/app/(tabs)/documents/layout.tsx
@@ -1,0 +1,10 @@
+import Header from "@/app/components/header";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-dvh flex-col">
+      <Header />
+      <div className="flex-1 px-6">{children}</div>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/documents/page.tsx
+++ b/packages/frontend/app/(tabs)/documents/page.tsx
@@ -1,0 +1,39 @@
+import { FALLBACK_MOCK_DATA } from "@/app/lib/mock/documents";
+import DocumentsClient from "./components/documents-client";
+
+export const dynamic = "force-dynamic";
+
+async function getDocuments() {
+  if (process.env.NODE_ENV === "development") {
+    return { documents: FALLBACK_MOCK_DATA };
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/document?page=1&take=20`,
+    {
+      method: "GET",
+      cache: "no-store",
+    },
+  );
+
+  if (!res.ok) {
+    return { documents: [] };
+  }
+
+  return res.json();
+}
+
+export default async function Page() {
+  const data = await getDocuments();
+  const documents = data?.documents ?? [];
+
+  return (
+    <div>
+      <main className="mx-auto max-w-180">
+        <div className="mt-12">
+          <DocumentsClient initialDocuments={documents} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/documents/page.tsx
+++ b/packages/frontend/app/(tabs)/documents/page.tsx
@@ -28,12 +28,16 @@ export default async function Page() {
   const documents = data?.documents ?? [];
 
   return (
-    <div>
-      <main className="mx-auto max-w-180">
-        <div className="mt-12">
-          <DocumentsClient initialDocuments={documents} />
-        </div>
-      </main>
+    <div className="mx-auto max-w-7xl py-12">
+      <header className="mb-10 space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          서류 관리
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          면접에 활용할 자기소개서와 포트폴리오를 관리하세요.
+        </p>
+      </header>
+      <DocumentsClient initialDocuments={documents} />
     </div>
   );
 }

--- a/packages/frontend/app/hooks/use-documents.ts
+++ b/packages/frontend/app/hooks/use-documents.ts
@@ -64,5 +64,9 @@ export function useDocuments(userId: string) {
     loadDocs();
   }, [userId]);
 
-  return { documents, isLoading };
+  const addDocument = (newDocument: DocumentItem) => {
+    setDocuments((prev) => [newDocument, ...prev]);
+  };
+
+  return { documents, isLoading, addDocument };
 }

--- a/packages/frontend/app/hooks/use-documents.ts
+++ b/packages/frontend/app/hooks/use-documents.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 import { DocumentItem } from "@/app/(tabs)/(simulator)/components/document-card";
+import { FALLBACK_MOCK_DATA } from "@/app/lib/mock/documents";
+import { formatIsoDateToDot } from "@/app/lib/utils";
 
 // API 응답 타입 정의
 interface ApiDocumentItem {
@@ -12,24 +14,6 @@ interface ApiDocumentItem {
 interface DocumentResponse {
   documents: ApiDocumentItem[];
 }
-
-// 서버가 응답하지 않을 때 보여줄 임시 데이터
-const FALLBACK_MOCK_DATA: DocumentItem[] = [
-  {
-    documentId: "mock-1",
-    type: "COVER_LETTER",
-    title: "[DEV] 2024 하반기 공통 자소서",
-    createdAt: "2024.05.12",
-    modifiedAt: "2024.05.12",
-  },
-  {
-    documentId: "mock-2",
-    type: "PORTFOLIO",
-    title: "[DEV] FE 아키텍트 포트폴리오",
-    createdAt: "2024.04.28",
-    modifiedAt: "2024.04.28",
-  },
-];
 
 export function useDocuments(userId: string) {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
@@ -62,8 +46,8 @@ export function useDocuments(userId: string) {
           documentId: item.documentId,
           type: item.type === "COVER" ? "COVER_LETTER" : "PORTFOLIO",
           title: item.title,
-          createdAt: item.createdAt.split("T")[0].replace(/-/g, "."),
-          modifiedAt: item.createdAt.split("T")[0].replace(/-/g, "."),
+          createdAt: formatIsoDateToDot(item.createdAt),
+          modifiedAt: formatIsoDateToDot(item.createdAt),
         }));
         setDocuments(mapped);
       } catch (err) {

--- a/packages/frontend/app/lib/client/document.ts
+++ b/packages/frontend/app/lib/client/document.ts
@@ -1,0 +1,157 @@
+import { DocumentItem } from "@/app/(tabs)/(simulator)/components/document-card";
+
+interface QuestionAnswer {
+  question: string;
+  answer: string;
+}
+
+interface CreateCoverLetterParameters {
+  title: string;
+  qa: QuestionAnswer[];
+}
+
+interface CreatePortfolioParameters {
+  title: string;
+  content: string;
+}
+
+/**
+ * [임시 벌크] 클라이언트에서 개별 삭제 API를 반복 호출하여 일괄 삭제를 수행함.
+ * 나중에 단일 API로 일괄 삭제하는 진짜 Bulk API가 나오기 전까지 사용.
+ */
+export async function deleteDocumentsClientSideBulk(
+  documentIds: string[],
+  documentsMap?: Record<string, DocumentItem>,
+): Promise<{ successIds: string[]; failedIds: string[] }> {
+  if (process.env.NODE_ENV === "development") {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return { successIds: documentIds, failedIds: [] };
+  }
+
+  const deletionPromises = documentIds.map(async (documentId) => {
+    try {
+      const document = documentsMap ? documentsMap[documentId] : undefined;
+      const documentType = document?.type ?? "PORTFOLIO";
+
+      const endpoint =
+        documentType === "COVER_LETTER"
+          ? `${process.env.NEXT_PUBLIC_API_URL}/document/${documentId}/cover-letter`
+          : `${process.env.NEXT_PUBLIC_API_URL}/document/${documentId}/portfolio`;
+
+      const response = await fetch(endpoint, { method: "DELETE" });
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete document: ${documentId}`);
+      }
+
+      return { documentId, isSuccess: true };
+    } catch (error) {
+      console.error(`Error deleting document ${documentId}:`, error);
+      return { documentId, isSuccess: false };
+    }
+  });
+
+  const results = await Promise.all(deletionPromises);
+
+  const successIds = results
+    .filter((result) => result.isSuccess)
+    .map((result) => result.documentId);
+
+  const failedIds = results
+    .filter((result) => !result.isSuccess)
+    .map((result) => result.documentId);
+
+  return { successIds, failedIds };
+}
+
+/**
+ * 새 자기소개서를 생성하는 함수
+ */
+export async function createCoverLetter(
+  parameters: CreateCoverLetterParameters,
+): Promise<DocumentItem> {
+  if (process.env.NODE_ENV === "development") {
+    const currentTime = new Date().toISOString();
+    return {
+      documentId: `mock-cover-${Date.now()}`,
+      type: "COVER_LETTER",
+      title: parameters.title || "Untitled Cover Letter",
+      createdAt: currentTime,
+      modifiedAt: currentTime,
+    };
+  }
+
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/document/cover-letter/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: parameters.title,
+        content: parameters.qa,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to create cover letter");
+  }
+
+  const responseData = await response.json();
+
+  return {
+    documentId: responseData.documentId,
+    type: responseData.type,
+    title: responseData.title,
+    createdAt: responseData.createdAt,
+    modifiedAt: responseData.modifiedAt,
+  };
+}
+
+/**
+ * 새 포트폴리오를 생성하는 함수
+ */
+export async function createPortfolio(
+  parameters: CreatePortfolioParameters,
+): Promise<DocumentItem> {
+  if (process.env.NODE_ENV === "development") {
+    const currentTime = new Date().toISOString();
+    return {
+      documentId: `mock-portfolio-${Date.now()}`,
+      type: "PORTFOLIO",
+      title: parameters.title || "Untitled Portfolio",
+      createdAt: currentTime,
+      modifiedAt: currentTime,
+    };
+  }
+
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/document/portfolio/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: parameters.title,
+        content: parameters.content,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to create portfolio");
+  }
+
+  const responseData = await response.json();
+
+  return {
+    documentId: responseData.documentId,
+    type: responseData.type,
+    title: responseData.title,
+    createdAt: responseData.createdAt,
+    modifiedAt: responseData.modifiedAt,
+  };
+}

--- a/packages/frontend/app/lib/mock/documents.ts
+++ b/packages/frontend/app/lib/mock/documents.ts
@@ -1,0 +1,20 @@
+import type { DocumentItem } from "@/app/(tabs)/(simulator)/components/document-card";
+
+export const FALLBACK_MOCK_DATA: DocumentItem[] = [
+  {
+    documentId: "mock-1",
+    type: "COVER_LETTER",
+    title: "[DEV] 2024 하반기 공통 자소서",
+    createdAt: "2024.05.12",
+    modifiedAt: "2024.05.12",
+  },
+  {
+    documentId: "mock-2",
+    type: "PORTFOLIO",
+    title: "[DEV] FE 아키텍트 포트폴리오",
+    createdAt: "2024.04.28",
+    modifiedAt: "2024.04.28",
+  },
+];
+
+export default FALLBACK_MOCK_DATA;

--- a/packages/frontend/app/lib/utils.ts
+++ b/packages/frontend/app/lib/utils.ts
@@ -1,6 +1,11 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function formatIsoDateToDot(dateIso: string) {
+  if (!dateIso) return "";
+  return String(dateIso).split("T")[0].replace(/-/g, ".");
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #103 

## ✅ 완료 작업 목록

- [x] Documents 페이지 UI 구현 (목록 조회, 선택, 삭제)
- [x] 서류 생성 모달 컴포넌트 구현 (커버레터/포트폴리오)
- [x] 서류 생성/삭제 API 클라이언트 함수 구현
- [x] 개발 모드에서 Mock 데이터 반환 로직 추가
- [x] DocumentCard에 삭제 모드 표시 기능 추가
- [x] 일괄 삭제 기능 구현 (클라이언트 사이드 벌크 삭제)
- [x] 인터뷰 생성 페이지에 서류 업로드 모달 연동

---

## 💬 리뷰어에게

- Documents 페이지에서 서류 생성, 조회, 삭제가 모두 동작합니다.
- 개발 모드([NODE_ENV === "development"]에서는 실제 API 호출 없이 Mock 데이터를 사용합니다.
- 인터뷰 생성 페이지의 "새 서류 업로드" 버튼도 실제로 동작하도록 구현했습니다.
- 삭제는 현재 클라이언트에서 개별 API를 반복 호출하는 방식이며, 추후 벌크 삭제 API로 개선 예정입니다.
---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 첫 번째 고민 ]**

- **문제점**: 여러개의 문서를 삭제하기 위해서는 /document/{documentId}/portfolio, /document/{documentId}/cover-letter에 각각 한개씩 삭제 요청을 보내야함.
- **해결 과정**: 현재 개별 삭제 요청을 보내되, 나중에 Document ID들을 이용해 다중 삭제가 가능한 API가 구현 된다면, 이를 적용할 예정

**[ 두 번째 고민 ]**

- **문제점**: 문서 관리 페이지에서 문서들을 다중 선택시에는 삭제버튼을 보여줘야 하고, 인터뷰 생성 페이지에서는 그렇지 않아야 함.
- **해결 과정**: 새로운 Props를 추가하여, 이를 화면마다 다르게 사용할 수 있도록 했습니다.

---

## 📸 스크린샷

<img width="1895" height="897" alt="image" src="https://github.com/user-attachments/assets/73fe1a58-c782-4746-9876-456ff79b48ea" />

<img width="1157" height="597" alt="image" src="https://github.com/user-attachments/assets/32cb1bec-6124-493c-bcae-c58f2f43c62b" />

<img width="1047" height="556" alt="image" src="https://github.com/user-attachments/assets/d7d82463-58e4-4aae-b187-dc35b46d3b4a" />




