### PR TITLE
fix: 인터뷰 목록에서 interviews가 undefined일 경우 처리, 동적 렌더링 하도록 수정

### DIFF
--- a/packages/frontend/app/(tabs)/dashboard/components/interview-list.tsx
+++ b/packages/frontend/app/(tabs)/dashboard/components/interview-list.tsx
@@ -21,7 +21,7 @@ export default function InterviewList({
         </div>
       </div>
       <div className="mt-6 flex flex-col gap-5">
-        {interviews.map((interview) => (
+        {interviews?.map((interview) => (
           <div
             className="group flex cursor-pointer flex-row items-center justify-center rounded-3xl border px-7 py-6 shadow-md"
             key={interview.createdAt}

--- a/packages/frontend/app/(tabs)/dashboard/page.tsx
+++ b/packages/frontend/app/(tabs)/dashboard/page.tsx
@@ -6,6 +6,8 @@ import InterviewStartBox from "./components/interview-start-box";
 import InterviewWelomeHeader from "./components/interview-welcome-header";
 import Tip from "../(simulator)/interview/[id]/result/components/tip";
 
+export const dynamic = "force-dynamic";
+
 const getCachedInterviews = nextCache(getInterviews, [
   "interviews_dashboard_page",
 ]);


### PR DESCRIPTION
## 🎯 이슈 번호

- close #111 

## ✅ 완료 작업 목록

- [x] 대시보드 페이지 렌더링 시 면접 목록이 없어도 에러나지 않도록 수정
- [x] 대시보드 페이지 동적 렌더링 하도록 수정

---

## 💬 리뷰어에게

자세한 내용은 이슈에 적혀있고, 곧이어 쿠키가 적용될거기 때문에 간단한 처리만 해두었습니다.

---

## 📸 스크린샷
