### PR TITLE
[Feature] 사용자는 면접 서류를 여러 개 삭제할 수 있다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
           CLOVA_SPEECH_API_KEY: ${{ secrets.CLOVA_SPEECH_API_KEY }}
           CLOVA_API_URL: ${{ secrets.CLOVA_API_URL }}
           CLOVA_API_KEY: ${{ secrets.CLOVA_API_KEY }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          JWT_ACCESS_TOKEN_EXPIRATION: 12h
+          JWT_REFRESH_TOKEN_EXPIRATION: 14d
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          OAUTH_REDIRECT_URI: http://localhost:8000/auth/signup/oauth
 
 
       # 2. 테스트 결과 시각화

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -22,6 +22,10 @@ import { CreateCoverLetterRequestDto } from './dto/create-cover-letter-request.d
 import { CreateCoverLetterResponseDto } from './dto/create-cover-letter-response.dto';
 import { UpdateCoverLetterRequestDto } from './dto/update-cover-letter-request.dto';
 import { CoverLetterDetailResponseDto } from './dto/cover-letter-detail-response.dto';
+import { UpdatePortfolioRequestDto } from './dto/update-portfolio-request.dto';
+
+import { BulkDeleteDocumentRequestDto } from './dto/bulk-delete-document-request.dto';
+import { BulkDeleteDocumentResponseDto } from './dto/bulk-delete-document-response.dto';
 
 @Controller('document')
 export class DocumentController {
@@ -121,6 +125,17 @@ export class DocumentController {
       take,
       type,
       sort,
+    );
+  }
+
+  @Delete()
+  async bulkDeleteDocuments(
+    @Body() dto: BulkDeleteDocumentRequestDto,
+  ): Promise<BulkDeleteDocumentResponseDto> {
+    const userId = '1';
+    return await this.documentService.bulkDeleteDocuments(
+      userId,
+      dto.documentIds,
     );
   }
 }

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -22,7 +22,6 @@ import { CreateCoverLetterRequestDto } from './dto/create-cover-letter-request.d
 import { CreateCoverLetterResponseDto } from './dto/create-cover-letter-response.dto';
 import { UpdateCoverLetterRequestDto } from './dto/update-cover-letter-request.dto';
 import { CoverLetterDetailResponseDto } from './dto/cover-letter-detail-response.dto';
-import { UpdatePortfolioRequestDto } from './dto/update-portfolio-request.dto';
 
 import { BulkDeleteDocumentRequestDto } from './dto/bulk-delete-document-request.dto';
 import { BulkDeleteDocumentResponseDto } from './dto/bulk-delete-document-response.dto';

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,11 +1,12 @@
 import {
+  BadRequestException,
   Injectable,
   InternalServerErrorException,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { DocumentRepository } from './repositories/document.repository';
-import { DataSource, EntityManager } from 'typeorm';
+import { DataSource, EntityManager, In } from 'typeorm';
 import { Portfolio } from './entities/portfolio.entity';
 import { Document, DocumentType } from './entities/document.entity';
 import { UserService } from '../user/user.service';
@@ -15,6 +16,7 @@ import { CoverLetter } from './entities/cover-letter.entity';
 import { CoverLetterQuestionAnswer } from './entities/cover-letter-question-answer.entity';
 import { CoverLetterQnA } from './dto/create-cover-letter-request.dto';
 import { UpdateCoverLetterRequestDto } from './dto/update-cover-letter-request.dto';
+import { BulkDeleteDocumentResponseDto } from './dto/bulk-delete-document-response.dto';
 
 @Injectable()
 export class DocumentService {
@@ -341,5 +343,46 @@ export class DocumentService {
     }
 
     return document;
+  }
+
+  async bulkDeleteDocuments(
+    userId: string,
+    documentIds: string[],
+  ): Promise<BulkDeleteDocumentResponseDto> {
+    const documents = await this.documentRepository.findAllByDocumentIds(
+      userId,
+      documentIds,
+    );
+
+    if (documents.length === 0) {
+      this.logger.warn(
+        `문서를 찾을 수 없습니다. documentIds=${documentIds.join(',')}`,
+      );
+      throw new BadRequestException(`문서를 찾을 수 없습니다.`);
+    }
+
+    const foundIds = documents.map((d) => d.documentId);
+    const failedDocuments = documentIds.filter(
+      (id) => !this.isFoundDocumentId(id, foundIds),
+    );
+
+    if (foundIds.length > 0) {
+      await this.documentRepository.delete({ documentId: In(foundIds) });
+    }
+
+    return {
+      success: true,
+      requestedCount: documentIds.length,
+      deletedCount: foundIds.length,
+      failedDocuments,
+    };
+  }
+
+  private isFoundDocumentId(id: string, ids: string[]) {
+    if (ids.includes(id)) {
+      return true;
+    }
+    this.logger.warn(`pk가 ${id}인 문서 삭제에 실패했습니다.`);
+    return false;
   }
 }

--- a/packages/backend/src/document/dto/bulk-delete-document-request.dto.ts
+++ b/packages/backend/src/document/dto/bulk-delete-document-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsArray, IsString } from 'class-validator';
+
+export class BulkDeleteDocumentRequestDto {
+  @IsArray()
+  @IsString({ each: true })
+  documentIds: string[];
+}

--- a/packages/backend/src/document/dto/bulk-delete-document-response.dto.ts
+++ b/packages/backend/src/document/dto/bulk-delete-document-response.dto.ts
@@ -1,0 +1,6 @@
+export class BulkDeleteDocumentResponseDto {
+  success: boolean;
+  requestedCount: number;
+  deletedCount: number;
+  failedDocuments: string[];
+}

--- a/packages/backend/src/document/repositories/document.repository.ts
+++ b/packages/backend/src/document/repositories/document.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { Document, DocumentType } from '../entities/document.entity';
 import { SortType } from '../dto/document-summary.request.dto';
 
@@ -87,5 +87,19 @@ export class DocumentRepository extends Repository<Document> {
     queryBuilder.orderBy('document.createdAt', sort).skip(skip).take(take);
 
     return await queryBuilder.getManyAndCount();
+  }
+
+  async findAllByDocumentIds(
+    userId: string,
+    documentIds: string[],
+  ): Promise<Document[]> {
+    const documents = await this.find({
+      select: { documentId: true },
+      where: {
+        documentId: In(documentIds),
+        user: { userId },
+      },
+    });
+    return documents;
   }
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #105

## ✅ 완료 작업 목록

- [x] 문서 일괄 삭제 API (`DELETE /document`) 구현
- [x] 요청/응답 DTO 및 유효성 검증 로직 추가 (`BulkDeleteDocumentRequestDto`)
- [x] 존재하지 않는 문서 ID에 대한 예외 처리 (`BadRequestException`)
- [x] 일괄 삭제 E2E 테스트 코드 추가 및 검증 (`document.e2e-test.ts`)

---

## 💬 리뷰어에게

### 1. DB 레벨 Cascade 삭제 활용
`Document` 엔티티와 연관된 `Portfolio`, `CoverLetter` 등은 모두 `ON DELETE CASCADE`가 설정되어 있습니다. 따라서 성능 효율성을 위해 애플리케이션 레벨의 삭제(`remove`)가 아닌 **DB 레벨의 삭제(`delete`)**를 선택했습니다. 단건 삭제와 달리 일괄 삭제에서는 객체를 메모리에 로드하는 오버헤드를 줄이는 것이 중요하다고 판단했습니다.

### 2. E2E 테스트 검증 완료
`delete` 메서드 사용 시 로직 검증을 위해 `document.e2e-test.ts`에 다음 케이스들을 포함시켰습니다:
- **성공**: 2개의 문서를 생성 후 일괄 삭제 시 DB에서 정상 삭제 확인
- **부분 성공**: 존재하는 문서와 존재하지 않는 문서를 함께 요청 시, 존재하는 것만 삭제하고 결과 반환
- **실패**: 존재하지 않는 문서만 요청 시 `400 BadRequest` 반환

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ `remove()` vs `delete()` 선택 기준 ]**

*   **문제점**: 초기에는 `remove()`를 사용하여 TypeORM의 라이프사이클 훅을 활용하려 했으나, 대량의 데이터를 삭제할 때 불필요한 `SELECT` 쿼리와 메모리 사용량이 발생하는 단점이 있었습니다.
*   **해결**: 
    *   **단건 삭제**의 경우: 이미 조회된 엔티티가 있고, 삭제 로그 기록 등 후처리가 필요할 수 있어 `remove()`가 적합합니다.
    *   **일괄 삭제**의 경우: 단순히 데이터를 빠르게 정리하는 것이 목적이므로, 불필요한 조회를 줄이고 쿼리 한 번으로 처리할 수 있는 `delete()`를 사용하는 것이 더 효율적이라 판단하여 변경했습니다.

---

## 📸 스크린샷
<img width="1829" height="373" alt="image" src="https://github.com/user-attachments/assets/222e9e21-1fe2-4b6f-970c-4efaca4f527d" />

<img width="1952" height="584" alt="image" src="https://github.com/user-attachments/assets/9df6a079-135f-4e3d-bf43-d221090cfd71" />
