### PR TITLE
[Feature] 백엔드 서버는 가드로 사용자를 인증할 수 있다.

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -1,4 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { LoggerMiddleware } from './common/middlewares/logger.middleware';
 import { AuthModule } from './auth/auth.module';
 import { DocumentModule } from './document/document.module';
@@ -41,7 +43,12 @@ import { winstonOptions } from './common/logger/winston.config';
     SeedModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { TokenResponse } from './dto/token-response.dto';
+import { Public } from './public.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -15,6 +16,7 @@ export class AuthController {
     this.redirectUri = configService.getOrThrow<string>('OAUTH_REDIRECT_URI');
   }
 
+  @Public()
   @Get('login/url/google')
   getGoogleLoginUrl(): { url: string } {
     const url = `https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${this.redirectUri}&client_id=${this.googleClientId}`;
@@ -22,6 +24,7 @@ export class AuthController {
     return { url };
   }
 
+  @Public()
   @Get('/signup/oauth')
   async signup(@Query('code') code: string): Promise<TokenResponse> {
     return await this.authService.googleLogin(code);

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { UserModule } from '../user/user.module';
 import { GoogleOAuthService } from './google-oauth.service';
 import { JwtTokenProvider } from './jwt-token.provider';
 import { JwtTokenDecoder } from './jwt-token.decoder';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Module({
   imports: [
@@ -26,7 +27,8 @@ import { JwtTokenDecoder } from './jwt-token.decoder';
     GoogleOAuthService,
     JwtTokenProvider,
     JwtTokenDecoder,
+    JwtAuthGuard,
   ],
-  exports: [JwtTokenProvider, JwtTokenDecoder],
+  exports: [JwtTokenProvider, JwtTokenDecoder, JwtAuthGuard],
 })
 export class AuthModule {}

--- a/packages/backend/src/auth/jwt-auth.guard.ts
+++ b/packages/backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,49 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtTokenDecoder } from './jwt-token.decoder';
+import { Request } from 'express';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from './public.decorator';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(
+    private readonly jwtTokenDecoder: JwtTokenDecoder,
+    private readonly reflector: Reflector,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = this.extractTokenFromHeader(request);
+    const payload = this.jwtTokenDecoder.decodeToken(token);
+    request['user'] = { userId: payload.sub, role: payload.role };
+
+    return true;
+  }
+
+  private extractTokenFromHeader(request: Request): string {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+
+    if (type !== 'Bearer') {
+      throw new UnauthorizedException('Bearer 토큰 형식이 아닙니다.');
+    }
+
+    if (!token) {
+      throw new UnauthorizedException('Bearer 토큰이 존재하지 않습니다.');
+    }
+
+    return token;
+  }
+}

--- a/packages/backend/src/auth/jwt-token.provider.ts
+++ b/packages/backend/src/auth/jwt-token.provider.ts
@@ -5,47 +5,47 @@ import { UserRole } from '../user/entities/user.entity';
 
 @Injectable()
 export class JwtTokenProvider {
-    private readonly refreshTokenExpiration: string;
-    private readonly accessTokenExpiration: string;
-    constructor(
-        private readonly jwtService: JwtService,
-        private readonly configService: ConfigService,
-    ) {
-        this.accessTokenExpiration = this.configService.getOrThrow<string>(
-            'JWT_ACCESS_TOKEN_EXPIRATION',
-        );
-        this.refreshTokenExpiration = this.configService.getOrThrow<string>(
-            'JWT_REFRESH_TOKEN_EXPIRATION',
-        );
-    }
+  private readonly refreshTokenExpiration: string;
+  private readonly accessTokenExpiration: string;
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {
+    this.accessTokenExpiration = this.configService.getOrThrow<string>(
+      'JWT_ACCESS_TOKEN_EXPIRATION',
+    );
+    this.refreshTokenExpiration = this.configService.getOrThrow<string>(
+      'JWT_REFRESH_TOKEN_EXPIRATION',
+    );
+  }
 
-    async generateAccessToken(
-        userId: string,
-        role: UserRole,
-        issuedAt: number,
-    ): Promise<string> {
-        const payload = {
-            sub: userId,
-            role,
-            iat: issuedAt,
-        };
-        return await this.jwtService.signAsync(payload, {
-            expiresIn: this.accessTokenExpiration,
-        } as JwtSignOptions);
-    }
+  async generateAccessToken(
+    userId: string,
+    role: UserRole,
+    issuedAt: number,
+  ): Promise<string> {
+    const payload = {
+      sub: userId,
+      role,
+      iat: issuedAt,
+    };
+    return await this.jwtService.signAsync(payload, {
+      expiresIn: this.accessTokenExpiration,
+    } as JwtSignOptions);
+  }
 
-    async generateRefreshToken(
-        userId: string,
-        role: UserRole,
-        issuedAt: number,
-    ): Promise<string> {
-        const payload = {
-            sub: userId,
-            role,
-            iat: issuedAt,
-        };
-        return await this.jwtService.signAsync(payload, {
-            expiresIn: this.refreshTokenExpiration,
-        } as JwtSignOptions);
-    }
+  async generateRefreshToken(
+    userId: string,
+    role: UserRole,
+    issuedAt: number,
+  ): Promise<string> {
+    const payload = {
+      sub: userId,
+      role,
+      iat: issuedAt,
+    };
+    return await this.jwtService.signAsync(payload, {
+      expiresIn: this.refreshTokenExpiration,
+    } as JwtSignOptions);
+  }
 }

--- a/packages/backend/src/auth/public.decorator.ts
+++ b/packages/backend/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);


### PR DESCRIPTION
## 🎯 이슈 번호

- close #122

## ✅ 완료 작업 목록

- [x] `JwtAuthGuard` 구현: JWT 토큰 추출 및 검증, 사용자 정보 Request 주입
- [x] `@Public` 데코레이터 구현: 인증 제외 라우트 설정
- [x] 전역 Guard 설정: `AppModule`에 `JwtAuthGuard`를 전역으로 등록
- [x] 로그인/회원가입 API (`AuthController`)에 `@Public` 적용하여 인증 제외

---

## 💬 리뷰어에게

- **JwtAuthGuard**: `CanActivate`를 구현하여 요청 헤더의 Bearer 토큰을 검증합니다. 유효한 토큰인 경우 디코딩된 정보를 `request.user`에 저장합니다.
- **Public 예외 처리**: 로그인이나 회원가입처럼 인증이 필요 없는 엔드포인트는 `@Public()` 데코레이터를 붙여 Guard가 검증을 건너뛰도록 처리했습니다. 이 외의 API는 전역 가드에 의해 사용자 인증을 요구합니다.

> nest.js 공식 문서를 기반으로 최대한 구현해봤습니다.
---

## 참고 자료
[nest.js Authentication 공식 문서](https://docs.nestjs.com/security/authentication)