### PR TITLE
[Feature] 인터뷰 목록 조회에 score 필드 추가

### DIFF
--- a/packages/backend/src/interview/dto/interview-summary.response.dto.ts
+++ b/packages/backend/src/interview/dto/interview-summary.response.dto.ts
@@ -10,4 +10,5 @@ export class InterviewSummaryResponse {
   title: string;
   type: InterviewType;
   createdAt: Date;
+  score?: string;
 }

--- a/packages/backend/src/interview/interview.service.ts
+++ b/packages/backend/src/interview/interview.service.ts
@@ -43,7 +43,7 @@ export class InterviewService {
     private readonly coverLetterRepository: CoverLetterRepository,
     private readonly documentRepository: DocumentRepository,
     private readonly interviewFeedBackService: InterviewFeedbackService,
-  ) {}
+  ) { }
 
   async calculateInterviewTime(
     userId: string,
@@ -332,6 +332,7 @@ export class InterviewService {
         title: interview.title,
         type: interview.type,
         createdAt: interview.createdAt,
+        score: interview.score,
       };
     });
 


### PR DESCRIPTION
## 🎯 이슈 번호

- close #126

## ✅ 완료 작업 목록

- [x] 인터뷰 목록 조회 API 응답(`InterviewSummaryResponse`)에 점수(`score`) 필드 추가
- [x] `InterviewService.listInterviews`에서 점수 데이터 매핑 처리

---

## 💬 리뷰어에게

- 대시보드 화면에서 각 면접의 AI 평가 점수를 표시하기 위해, 목록 조회 API(`GET /interview`) 응답에 `score` 필드를 포함시켰습니다.
- 기존에는 `score` 정보가 피드백 조회에서만 사용되었으나, 목록에서도 요약 정보로 제공할 필요가 있어 DTO를 수정했습니다.
- score가 없는 인터뷰도 존재할 수 있다고 생각했습니다.(인터뷰 중간에 브라우저 꺼버리는 경우). 이럴 때 면접의 ai score가 생기지 않을 수 있어 null을 반환하도록 했습니다.
--- 

## 참고 자료

<img width="1284" height="1366" alt="image" src="https://github.com/user-attachments/assets/ccacad17-8a68-450c-af60-42176339d6b0" />
