### PR TITLE
[Feature] 사용자는 사용자 정보를 조회할 수 있다.

### DIFF
--- a/packages/backend/src/user/dto/user-info-response.dto.ts
+++ b/packages/backend/src/user/dto/user-info-response.dto.ts
@@ -1,0 +1,5 @@
+export class UserInfoResponse {
+  userId: string;
+  email: string;
+  profileUrl: string;
+}

--- a/packages/backend/src/user/user.controller.ts
+++ b/packages/backend/src/user/user.controller.ts
@@ -1,4 +1,14 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
+import { UserService } from './user.service';
+import { GetUser } from '../auth/decorator/get-user.decorator';
+import { UserInfoResponse } from './dto/user-info-response.dto';
 
 @Controller('user')
-export class UserController {}
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get('me')
+  async getMe(@GetUser() userId: string): Promise<UserInfoResponse> {
+    return await this.userService.getUserProfile(userId);
+  }
+}

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { User } from './entities/user.entity';
 import { UserRepository } from './user.repository';
+import { UserInfoResponse } from './dto/user-info-response.dto';
 
 @Injectable()
 export class UserService {
@@ -31,5 +32,14 @@ export class UserService {
     user.profileUrl = profileUrl;
     user.sub = sub;
     return await this.userRepository.save(user);
+  }
+
+  async getUserProfile(userId: string): Promise<UserInfoResponse> {
+    const user = await this.findExistingUser(userId);
+    return {
+      userId: user.userId,
+      email: user.userEmail,
+      profileUrl: user.profileUrl,
+    };
   }
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #132

## ✅ 완료 작업 목록

- [x] 내 정보 조회 API (`GET /user/me`) 구현
- [x] `UserInfoResponse` DTO 추가
- [x] `UserService.getUserProfile` 메서드 구현

---

## 💬 리뷰어에게

- `UserController`에 `/user/me` 엔드포인트를 추가하여 현재 로그인한 사용자의 정보를 조회할 수 있도록 했습니다.
- `@GetUser()` 데코레이터를 사용하여 토큰에서 추출된 `userId`를 기반으로 서비스를 호출합니다.
- `UserInfoResponse`에는 클라이언트에서 필요한 최소한의 정보(`userId`, `email`, `profileUrl`)만 포함했습니다.
