### PR TITLE
[Refactor] json 강제하는 로직 개선

### DIFF
--- a/packages/backend/src/interview/interview-ai.service.ts
+++ b/packages/backend/src/interview/interview-ai.service.ts
@@ -130,10 +130,11 @@ export class InterviewAIService {
             
             ***[컨텍스트: 현재 입력]***
             - 직전 지원자 답변: ${currentAnswer || '없음 (첫 질문)'}
-
-            !!! 반드시 시스템 프롬프트에 정의된 JSON 형식으로만 답변하십시오. !!!
-            Format: { "question": "...", "tags": [...], "isLast": boolean }
         
+            ***[필수 규칙]***
+            - **빈 값 금지**: "question" 및 "tags" 배열의 항목은 절대 빈 문자열("")이어서는 안 됩니다. 반드시 유의미한 내용을 포함하십시오.
+            - 최소 10자 이상의 질문을 생성하십시오.
+
             ${isLastQuestion ? lastQuestPrompt : ''}
         `;
   }
@@ -171,6 +172,29 @@ export class InterviewAIService {
           temperature: 0.4,
           repeatPenalty: 1.1,
           seed: 0,
+          responseFormat: {
+            type: 'json',
+            schema: {
+              type: 'object',
+              properties: {
+                question: {
+                  type: 'string',
+                  minLength: 10,
+                },
+                tags: {
+                  type: 'array',
+                  minItems: 1,
+                  items: {
+                    type: 'string',
+                    minLength: 1,
+                  },
+                },
+                isLast: { type: 'boolean' },
+              },
+              required: ['question', 'tags', 'isLast'],
+              additionalProperties: false,
+            },
+          },
         }),
         signal: controller.signal,
       });

--- a/packages/backend/src/interview/interview.constants.ts
+++ b/packages/backend/src/interview/interview.constants.ts
@@ -51,14 +51,6 @@ Trigger: 답변은 타당하나 깊이/근거가 부족할 때.
 Trigger: 단순 사용 경험('User' level)에 그치거나 자동화된 동작 이해가 의심될 때.
 - 기술을 CS 원리(OS, Network, DB)와 연결.
 
-# Output Format (JSON Only)
-마크다운 없이 오직 JSON만 출력.
-{
-  "question": "지원자에게 던질 구체적 질문 (존댓말)",
-  "tags": ["핵심키워드1", "핵심키워드2"],
-  "isLast": true // boolean 필드
-}
-
 # Self-Check (Internal)
 - 생성된 question이 [제외된 주제]를 포함하는가? -> 즉시 폐기하고 다시 생성.
 - 지원자가 모른다고 했는가? -> 즉시 다른 주제로 전환했는가 확인.


### PR DESCRIPTION
## 🎯 이슈 번호

- close #143 

## ✅ 완료 작업 목록

- [x] AI 응답 형식 강제화 (JSON Schema)
  - `responseFormat`의 `schema` 옵션을 활용하여 AI 응답 규격 엄격하게 제한
  - `question`, `tags`, `isLast` 필드 구조를 API 레벨에서 보장
- [x] 응답 필드 누락 및 빈 값 방어 로직 강화
  - Schema 내 `minLength`(질문 10자 이상, 태그 1자 이상) 및 `minItems`(태그 최소 1개) 제약 추가
  - 프롬프트 내 `[필수 규칙]` 섹션 및 `빈 값 금지` 지침 명시

---

## 💬 리뷰어에게

Clova API의 `responseFormat` 기능을 도입하여 응답 형식을 강제했습니다. 
단순히 규격만 맞추는 것이 아니라, 실질적인 데이터(질문 내용 등)가 비어 있는 문제를 해결하기 위해 Schema의 제약 조건(`minLength`)과 프롬프트 가이드라인을 결합하여 응답의 품질과 안정성을 동시에 확보했습니다.

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ 형식 강제화 이후의 빈 값(Empty Value) 문제 해결 ]**

- **문제점**: `responseFormat: { type: 'json' }`을 적용하여 JSON 형식은 보장되었으나, AI가 `"question": ""` 또는 `"tags": []`와 같이 구조는 맞지만 실제 내용이 비어 있는 응답을 보내 시스템 로직에 결함이 발생하는 경우가 확인됨.
- **해결 과정**:
    1. **Schema 제약 조건 활용**: JSON Schema 정의 시 `minLength: 10` 등을 추가하여, AI가 규격을 맞추더라도 내용이 부족하면 API 레벨에서 다시 생성하거나 오류를 인지하도록 유도함.
    2. **프롬프트 규칙과의 상호 보완**: 프롬프트에도 `[필수 규칙]`을 명시하여 '빈 값 금지'와 '최소 길이' 조건을 AI가 명확히 인지하게 함으로써, 기술적 제약(Schema)과 논리적 가이드(Prompt)가 이중으로 응답 품질을 방어하도록 구성함.
