### PR TITLE
[Fix] 비디오 다시보기 버그 수정

### DIFF
--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/client.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/client.tsx
@@ -135,25 +135,29 @@ export default function InterviewClient({
 
   // 인터뷰 시작 시: interviewId 기준으로 비디오 녹화 자동 시작
   const sessionRecordingInitRef = useRef(false);
+
   useEffect(() => {
     if (sessionRecordingInitRef.current) return;
     if (!videoStream) return;
     if (!sessionStream) return;
-    if (isSessionRecording) return;
 
     sessionRecordingInitRef.current = true;
     startSessionVideoRecording();
-
-    return () => {
-      void stopSessionVideoRecording();
-    };
   }, [
-    isSessionRecording,
-    sessionStream,
-    startSessionVideoRecording,
-    stopSessionVideoRecording,
     videoStream,
+    sessionStream,
+    isSessionRecording,
+    startSessionVideoRecording,
   ]);
+
+  // cleanup은 별도 useEffect로 분리 (컴포넌트 언마운트 시에만)
+  useEffect(() => {
+    return () => {
+      if (sessionRecordingInitRef.current) {
+        void stopSessionVideoRecording();
+      }
+    };
+  }, [stopSessionVideoRecording]);
 
   useEffect(() => {
     return () => {

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/recent-recording.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/recent-recording.tsx
@@ -78,7 +78,7 @@ export default function RecentRecording({
       <video
         src={url || ""}
         controls
-        preload="metadata"
+        preload="auto"
         className="aspect-video w-full rounded-lg bg-black"
         playsInline
         onError={() => {

--- a/packages/frontend/app/error.tsx
+++ b/packages/frontend/app/error.tsx
@@ -11,40 +11,36 @@ export default function GlobalError({
   reset: () => void;
 }) {
   return (
-    <html className="flex size-full items-center justify-center">
-      <body className="w-full">
-        <div className="flex flex-col items-center justify-center gap-6 p-4">
-          <MountainSnow className="size-12 text-primary" />
+    <div className="flex size-full flex-col items-center justify-center gap-6 p-4">
+      <MountainSnow className="size-12 text-primary" />
 
-          <div className="text-center">
-            <h1 className="mb-2 text-3xl font-bold">
-              어라..? 뭔가 잘못된거 같군요..
-            </h1>
-            {/* <p className="mb-4 text-lg text-gray-600">{error.message}</p> */}
-            {error.digest && (
-              <p className="text-xs text-gray-400">Error ID: {error.digest}</p>
-            )}
-          </div>
+      <div className="text-center">
+        <h1 className="mb-2 text-3xl font-bold">
+          어라..? 뭔가 잘못된거 같군요..
+        </h1>
+        {/* <p className="mb-4 text-lg text-gray-600">{error.message}</p> */}
+        {error.digest && (
+          <p className="text-xs text-gray-400">Error ID: {error.digest}</p>
+        )}
+      </div>
 
-          <div className="flex gap-3">
-            <Button className="cursor-pointer" onClick={() => reset()}>
-              <Hammer />
-              <p>다시 시도하기</p>
-            </Button>
-            <Button
-              className="cursor-pointer"
-              onClick={() => (window.location.href = "/")}
-            >
-              <House />
-              <p>홈으로</p>
-            </Button>
-          </div>
+      <div className="flex gap-3">
+        <Button className="cursor-pointer" onClick={() => reset()}>
+          <Hammer />
+          <p>다시 시도하기</p>
+        </Button>
+        <Button
+          className="cursor-pointer"
+          onClick={() => (window.location.href = "/")}
+        >
+          <House />
+          <p>홈으로</p>
+        </Button>
+      </div>
 
-          <p className="mt-4 text-sm text-gray-500">
-            이 문제가 계속되면 WEB 23에게 연락해주세요!
-          </p>
-        </div>
-      </body>
-    </html>
+      <p className="mt-4 text-sm text-gray-500">
+        이 문제가 계속되면 WEB 23에게 연락해주세요!
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## 🎯 이슈 번호

- close #165

## ✅ 완료 작업 목록

- [x] MediaRecorder cleanup 함수 분리하여 언마운트 시에만 실행되도록 수정
- [x] videoStream 체크 추가로 카메라 권한 없이 녹화 시작 방지
- [x] preload='auto' 설정으로 WebM duration 자동 계산

---


## 🤔 주요 고민 및 해결 과정 (선택)

**[ useEffect cleanup 조기 실행 문제 ]**

- **문제점**: sessionStream이 dependency에 포함되어 videoStream/audioStream 변경 시마다 cleanup이 실행되어 녹화가 중단됨
- **해결 과정**: cleanup 전용 useEffect를 별도로 분리하여 컴포넌트 언마운트 시에만 실행되도록 수정

**[ WebM duration 표시 문제 ]**

- **문제점**: MediaRecorder의 timeslice 사용 시 WebM 파일에 duration 메타데이터가 누락됨
- **해결 과정**: timeslice 제거 및 video 태그의 preload='auto' 설정으로 브라우저가 전체 파일을 스캔하여 duration 계산

---
