### PR TITLE
[Feature] result 페이지 기능 추가 (삭제, 피드백)

### DIFF
--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
@@ -94,3 +94,26 @@ export async function dislike({
     },
   );
 }
+
+export async function deleteInterview({
+  interviewId,
+  userToken,
+}: {
+  interviewId: string;
+  userToken: string;
+}) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/interview/${interviewId}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error("면접 삭제 실패");
+  }
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/actions.ts
@@ -57,6 +57,7 @@ export async function startFeedback({
   return (await res.json()) as IFeedback;
 }
 
+/* TODO: 백엔드 API 구현 후 활성화
 export async function like({
   interviewId,
   userToken,
@@ -94,6 +95,7 @@ export async function dislike({
     },
   );
 }
+*/
 
 export async function deleteInterview({
   interviewId,

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/delete-interview-button.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/delete-interview-button.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, X } from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { deleteInterview } from "../actions";
+
+export default function DeleteInterviewButton({
+  interviewId,
+  userToken,
+}: {
+  interviewId: string;
+  userToken: string;
+}) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteInterview({ interviewId, userToken });
+      router.push("/");
+    } catch (error) {
+      console.error("면접 삭제 실패:", error);
+    } finally {
+      setIsDeleting(false);
+      setShowConfirm(false);
+    }
+  };
+
+  if (showConfirm) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg">
+          <div className="mb-4 flex items-start justify-between">
+            <h3 className="text-lg font-semibold">면접 기록 삭제</h3>
+            <button
+              onClick={() => setShowConfirm(false)}
+              className="text-gray-400 hover:text-gray-600"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+          <p className="mb-6 text-sm text-gray-600">
+            정말로 이 면접 기록을 삭제하시겠습니까?
+            <br />
+            삭제된 데이터는 복구할 수 없습니다.
+          </p>
+          <div className="flex justify-end gap-3">
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirm(false)}
+              disabled={isDeleting}
+            >
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? "삭제 중..." : "삭제"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="destructive"
+      onClick={() => setShowConfirm(true)}
+      className="w-full sm:w-auto"
+    >
+      <Trash2 className="mr-2 h-4 w-4" />
+      면접 기록 삭제
+    </Button>
+  );
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/interview-feedback-buttons.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/interview-feedback-buttons.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { Heart, HeartOff, AlertCircle } from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { like, dislike } from "../actions";
+
+export default function InterviewFeedbackButtons({
+  interviewId,
+  userToken,
+}: {
+  interviewId: string;
+  userToken: string;
+}) {
+  const [feedback, setFeedback] = useState<"like" | "dislike" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLike = async () => {
+    setError(null);
+    try {
+      await like({ interviewId, userToken });
+      setFeedback("like");
+    } catch (error) {
+      console.error("좋아요 실패:", error);
+      setError("피드백 전송에 실패했습니다. 다시 시도해주세요.");
+      setTimeout(() => setError(null), 3000);
+    }
+  };
+
+  const handleDislike = async () => {
+    setError(null);
+    try {
+      await dislike({ interviewId, userToken });
+      setFeedback("dislike");
+    } catch (error) {
+      console.error("싫어요 실패:", error);
+      setError("피드백 전송에 실패했습니다. 다시 시도해주세요.");
+      setTimeout(() => setError(null), 3000);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex w-full items-center justify-between">
+        <span className="text-sm text-black/60">도움이 되었을까요?</span>
+        <div className="flex gap-2">
+          <Button
+            className="cursor-pointer"
+            onClick={handleLike}
+            variant={feedback === "like" ? "default" : "outline"}
+          >
+            <Heart
+              className={feedback === "like" ? "fill-current text-white" : ""}
+            />
+          </Button>
+          <Button
+            className="cursor-pointer"
+            onClick={handleDislike}
+            variant={feedback === "dislike" ? "default" : "outline"}
+          >
+            <HeartOff
+              className={
+                feedback === "dislike" ? "fill-current text-white" : ""
+              }
+            />
+          </Button>
+        </div>
+      </div>
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-sm text-red-600">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+      {feedback && !error && (
+        <div className="flex items-center justify-end text-sm text-green-600">
+          <span>피드백이 전송되었습니다. 감사합니다!</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/interview-feedback-buttons.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/components/interview-feedback-buttons.tsx
@@ -1,3 +1,4 @@
+/* TODO: 백엔드 like/dislike API 구현 후 활성화
 "use client";
 
 import { useState } from "react";
@@ -79,4 +80,9 @@ export default function InterviewFeedbackButtons({
       )}
     </div>
   );
+}
+*/
+
+export default function InterviewFeedbackButtons() {
+  return null;
 }

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/page.tsx
@@ -97,12 +97,14 @@ export default async function InterviewResultPage({
             <AISummary summary={feedbackResult.feedback || ""} />
           </Panel>
         </div>
+        {/* TODO: 백엔드 like/dislike API 구현 후 활성화
         <div className="mt-6">
           <InterviewFeedbackButtons
             interviewId={interviewId}
             userToken={user.token}
           />
         </div>
+        */}
         <div className="flex">
           <Panel className="flex-1 flex-row justify-start bg-primary/5 p-5">
             <Tip />

--- a/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/page.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/interview/[id]/result/page.tsx
@@ -11,6 +11,8 @@ import Panel from "./components/panel";
 import Score from "./components/score";
 import AISummary from "./components/ai-summary";
 import Tip from "./components/tip";
+import DeleteInterviewButton from "./components/delete-interview-button";
+import InterviewFeedbackButtons from "./components/interview-feedback-buttons";
 import { getUserSession } from "@/app/lib/server/session";
 import { timeAgo } from "@/app/lib/utils";
 
@@ -24,10 +26,6 @@ export default async function InterviewResultPage({
   if (!user) {
     return redirect("/");
   }
-
-  // sleep(2000);
-
-  // await new Promise((resolve) => setTimeout(resolve, 1000000));
 
   const { id: interviewId } = await params;
   let history: Awaited<ReturnType<typeof getHistory>>["history"] = [];
@@ -99,22 +97,23 @@ export default async function InterviewResultPage({
             <AISummary summary={feedbackResult.feedback || ""} />
           </Panel>
         </div>
+        <div className="mt-6">
+          <InterviewFeedbackButtons
+            interviewId={interviewId}
+            userToken={user.token}
+          />
+        </div>
         <div className="flex">
           <Panel className="flex-1 flex-row justify-start bg-primary/5 p-5">
             <Tip />
           </Panel>
         </div>
-        {/*  <div className="mt-12 flex w-full items-center justify-between">
-          <span className="text-sm text-black/60">도움이 되었을까요?</span>
-          <div className="flex gap-2">
-            <Button className="cursor-pointer">
-              <Heart className="text-white" />
-            </Button>
-            <Button className="cursor-pointer">
-              <HeartOff className="text-white" />
-            </Button>
-          </div>
-        </div> */}
+        <div className="flex justify-end">
+          <DeleteInterviewButton
+            interviewId={interviewId}
+            userToken={user.token}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/app/(tabs)/(simulator)/layout.tsx
+++ b/packages/frontend/app/(tabs)/(simulator)/layout.tsx
@@ -3,6 +3,7 @@ import Header from "@/app/components/header";
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-dvh flex-col">
+      <Header />
       <div className="flex-1">{children}</div>
     </div>
   );

--- a/packages/frontend/mocks/handlers.ts
+++ b/packages/frontend/mocks/handlers.ts
@@ -35,10 +35,36 @@ export const handlers = [
         history: [
           {
             question: {
-              content: "What is your strongest skill?",
-              createdAt: new Date().toISOString(),
+              content: "가장 강점이라고 생각하는 기술은 무엇인가요?",
+              createdAt: new Date(Date.now() - 300000).toISOString(),
             },
-            answer: null,
+            answer: {
+              content:
+                "저의 가장 큰 강점은 문제 해결 능력입니다. 복잡한 문제를 작은 단위로 나누어 해결하는 것을 잘합니다.",
+              createdAt: new Date(Date.now() - 240000).toISOString(),
+            },
+          },
+          {
+            question: {
+              content: "가장 도전적이었던 프로젝트에 대해 말씀해주세요.",
+              createdAt: new Date(Date.now() - 180000).toISOString(),
+            },
+            answer: {
+              content:
+                "대규모 웹 애플리케이션의 성능 최적화 프로젝트를 진행했습니다. 수백만 명의 사용자를 위한 성능 개선이 핵심 목표였습니다.",
+              createdAt: new Date(Date.now() - 120000).toISOString(),
+            },
+          },
+          {
+            question: {
+              content: "촉박한 마감은 어떻게 처리하시나요?",
+              createdAt: new Date(Date.now() - 60000).toISOString(),
+            },
+            answer: {
+              content:
+                "작업의 우선순위를 정하고, 팀과 명확하게 소통하며, 가장 중요한 기능을 먼저 완성하는 데 집중합니다.",
+              createdAt: new Date(Date.now() - 30000).toISOString(),
+            },
           },
         ],
       } as IHistoryResponse,
@@ -51,10 +77,36 @@ export const handlers = [
         history: [
           {
             question: {
-              content: "What is your strongest skill?",
-              createdAt: new Date().toISOString(),
+              content: "가장 강점이라고 생각하는 기술은 무엇인가요?",
+              createdAt: new Date(Date.now() - 300000).toISOString(),
             },
-            answer: null,
+            answer: {
+              content:
+                "저의 가장 큰 강점은 문제 해결 능력입니다. 복잡한 문제를 작은 단위로 나누어 해결하는 것을 잘합니다.",
+              createdAt: new Date(Date.now() - 240000).toISOString(),
+            },
+          },
+          {
+            question: {
+              content: "가장 도전적이었던 프로젝트에 대해 말씀해주세요.",
+              createdAt: new Date(Date.now() - 180000).toISOString(),
+            },
+            answer: {
+              content:
+                "대규모 웹 애플리케이션의 성능 최적화 프로젝트를 진행했습니다. 수백만 명의 사용자를 위한 성능 개선이 핵심 목표였습니다.",
+              createdAt: new Date(Date.now() - 120000).toISOString(),
+            },
+          },
+          {
+            question: {
+              content: "촉박한 마감은 어떻게 처리하시나요?",
+              createdAt: new Date(Date.now() - 60000).toISOString(),
+            },
+            answer: {
+              content:
+                "작업의 우선순위를 정하고, 팀과 명확하게 소통하며, 가장 중요한 기능을 먼저 완성하는 데 집중합니다.",
+              createdAt: new Date(Date.now() - 30000).toISOString(),
+            },
           },
         ],
       } as IHistoryResponse,
@@ -95,7 +147,7 @@ export const handlers = [
     return HttpResponse.json(
       {
         questionId: `q-${Date.now()}`,
-        question: "Explain event loop.",
+        question: "JavaScript의 이벤트 루프에 대해 설명해주세요.",
         isLast: false,
         createdAt: new Date().toISOString(),
       } as IGenerateQuestion,
@@ -106,7 +158,7 @@ export const handlers = [
     return HttpResponse.json(
       {
         questionId: `q-${Date.now()}`,
-        question: "Explain event loop.",
+        question: "JavaScript의 이벤트 루프에 대해 설명해주세요.",
         isLast: false,
         createdAt: new Date().toISOString(),
       } as IGenerateQuestion,
@@ -205,6 +257,8 @@ export const handlers = [
     return HttpResponse.json(
       {
         documentId: "mock-portfolio-1",
+        type: "PORTFOLIO",
+        portfolioId: "mock-portfolio-id-1",
         title: "포트폴리오",
         content: "포트폴리오 내용입니다.",
         createdAt: new Date().toISOString(),
@@ -217,6 +271,8 @@ export const handlers = [
     return HttpResponse.json(
       {
         documentId: "mock-portfolio-1",
+        type: "PORTFOLIO",
+        portfolioId: "mock-portfolio-id-1",
         title: "포트폴리오",
         content: "포트폴리오 내용입니다.",
         createdAt: new Date().toISOString(),
@@ -227,11 +283,36 @@ export const handlers = [
   }),
 
   // 포트폴리오 수정
-  http.patch(absolute(`/document/:documentId/portfolio`), async () => {
-    return HttpResponse.json({ success: true }, { status: 200 });
-  }),
-  http.patch(`/document/:documentId/portfolio`, async () => {
-    return HttpResponse.json({ success: true }, { status: 200 });
+  http.patch(
+    absolute(`/document/:documentId/portfolio`),
+    async ({ params }) => {
+      return HttpResponse.json(
+        {
+          documentId: params.documentId,
+          type: "PORTFOLIO",
+          portfolioId: "mock-portfolio-id-1",
+          title: "수정된 포트폴리오",
+          content: "수정된 내용입니다.",
+          createdAt: new Date(Date.now() - 86400000).toISOString(),
+          modifiedAt: new Date().toISOString(),
+        },
+        { status: 200 },
+      );
+    },
+  ),
+  http.patch(`/document/:documentId/portfolio`, async ({ params }) => {
+    return HttpResponse.json(
+      {
+        documentId: params.documentId,
+        type: "PORTFOLIO",
+        portfolioId: "mock-portfolio-id-1",
+        title: "수정된 포트폴리오",
+        content: "수정된 내용입니다.",
+        createdAt: new Date(Date.now() - 86400000).toISOString(),
+        modifiedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
   }),
 
   // 포트폴리오 삭제
@@ -247,8 +328,10 @@ export const handlers = [
     return HttpResponse.json(
       {
         documentId: "mock-cover-1",
+        coverLetterId: "mock-cover-letter-1",
+        type: "COVER",
         title: "자기소개서",
-        qa: [
+        content: [
           { question: "지원 동기는?", answer: "열정적으로 일하고 싶습니다." },
         ],
         createdAt: new Date().toISOString(),
@@ -261,8 +344,10 @@ export const handlers = [
     return HttpResponse.json(
       {
         documentId: "mock-cover-1",
+        coverLetterId: "mock-cover-letter-1",
+        type: "COVER",
         title: "자기소개서",
-        qa: [
+        content: [
           { question: "지원 동기는?", answer: "열정적으로 일하고 싶습니다." },
         ],
         createdAt: new Date().toISOString(),
@@ -273,11 +358,40 @@ export const handlers = [
   }),
 
   // 자기소개서 수정
-  http.put(absolute(`/document/:documentId/cover-letter`), async () => {
-    return HttpResponse.json({ success: true }, { status: 200 });
-  }),
-  http.put(`/document/:documentId/cover-letter`, async () => {
-    return HttpResponse.json({ success: true }, { status: 200 });
+  http.put(
+    absolute(`/document/:documentId/cover-letter`),
+    async ({ params }) => {
+      return HttpResponse.json(
+        {
+          documentId: params.documentId,
+          coverLetterId: "mock-cover-letter-1",
+          type: "COVER",
+          title: "수정된 자기소개서",
+          content: [
+            { question: "지원 동기는?", answer: "열정적으로 일하고 싶습니다." },
+          ],
+          createdAt: new Date(Date.now() - 86400000).toISOString(),
+          modifiedAt: new Date().toISOString(),
+        },
+        { status: 200 },
+      );
+    },
+  ),
+  http.put(`/document/:documentId/cover-letter`, async ({ params }) => {
+    return HttpResponse.json(
+      {
+        documentId: params.documentId,
+        coverLetterId: "mock-cover-letter-1",
+        type: "COVER",
+        title: "수정된 자기소개서",
+        content: [
+          { question: "지원 동기는?", answer: "열정적으로 일하고 싶습니다." },
+        ],
+        createdAt: new Date(Date.now() - 86400000).toISOString(),
+        modifiedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
   }),
 
   // 자기소개서 삭제
@@ -313,13 +427,21 @@ export const handlers = [
   // 피드백 생성
   http.post(absolute(`/interview/feedback`), async () => {
     return HttpResponse.json(
-      { feedbackId: `feedback-${Date.now()}` },
+      {
+        score: "85",
+        feedback:
+          "전반적으로 좋은 답변이었습니다. 명확한 설명과 논리적 사고가 돋보였습니다.",
+      },
       { status: 200 },
     );
   }),
   http.post(`/interview/feedback`, async () => {
     return HttpResponse.json(
-      { feedbackId: `feedback-${Date.now()}` },
+      {
+        score: "85",
+        feedback:
+          "전반적으로 좋은 답변이었습니다. 명확한 설명과 논리적 사고가 돋보였습니다.",
+      },
       { status: 200 },
     );
   }),
@@ -336,10 +458,9 @@ export const handlers = [
   http.get(absolute(`/interview/:interviewId/feedback`), async () => {
     return HttpResponse.json(
       {
-        feedback: "전반적으로 좋은 답변이었습니다.",
-        score: 85,
-        strengths: ["명확한 설명", "논리적 사고"],
-        improvements: ["구체적인 예시 추가"],
+        score: "85",
+        feedback:
+          "전반적으로 좋은 답변이었습니다. 명확한 설명과 논리적 사고가 돋보였습니다.",
       },
       { status: 200 },
     );
@@ -347,10 +468,9 @@ export const handlers = [
   http.get(`/interview/:interviewId/feedback`, async () => {
     return HttpResponse.json(
       {
-        feedback: "전반적으로 좋은 답변이었습니다.",
-        score: 85,
-        strengths: ["명확한 설명", "논리적 사고"],
-        improvements: ["구체적인 예시 추가"],
+        score: "85",
+        feedback:
+          "전반적으로 좋은 답변이었습니다. 명확한 설명과 논리적 사고가 돋보였습니다.",
       },
       { status: 200 },
     );
@@ -364,10 +484,26 @@ export const handlers = [
           {
             interviewId: "mock-interview-1",
             title: "기술 면접 시뮬레이션",
-            createdAt: new Date().toISOString(),
-            status: "completed",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 86400000).toISOString(),
+            score: "85",
+          },
+          {
+            interviewId: "mock-interview-2",
+            title: "프론트엔드 면접",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 172800000).toISOString(),
+            score: "92",
+          },
+          {
+            interviewId: "mock-interview-3",
+            title: "React 전문가 면접",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 259200000).toISOString(),
+            score: "78",
           },
         ],
+        totalPage: 1,
       },
       { status: 200 },
     );
@@ -379,12 +515,52 @@ export const handlers = [
           {
             interviewId: "mock-interview-1",
             title: "기술 면접 시뮬레이션",
-            createdAt: new Date().toISOString(),
-            status: "completed",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 86400000).toISOString(),
+            score: "85",
+          },
+          {
+            interviewId: "mock-interview-2",
+            title: "프론트엔드 면접",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 172800000).toISOString(),
+            score: "92",
+          },
+          {
+            interviewId: "mock-interview-3",
+            title: "React 전문가 면접",
+            type: "TECH",
+            createdAt: new Date(Date.now() - 259200000).toISOString(),
+            score: "78",
           },
         ],
+        totalPage: 1,
       },
       { status: 200 },
     );
+  }),
+
+  // 면접 삭제
+  http.delete(absolute(`/interview/:interviewId`), async () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.delete(`/interview/:interviewId`, async () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // 피드백 좋아요
+  http.post(absolute(`/interview/:interviewId/feedback/like`), async () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.post(`/interview/:interviewId/feedback/like`, async () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // 피드백 싫어요
+  http.post(absolute(`/interview/:interviewId/feedback/dislike`), async () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.post(`/interview/:interviewId/feedback/dislike`, async () => {
+    return new HttpResponse(null, { status: 204 });
   }),
 ];


### PR DESCRIPTION
## 🎯 이슈 번호

- close #171 

## ✅ 완료 작업 목록

- [x] MSW 핸들러를 백엔드 API 구조에 맞게 업데이트 (면접 히스토리, 피드백, 문서 응답 수정)
- [x] Simulator layout에 Header 추가
- [x] 면접 결과 좋아요/싫어요 피드백 기능 구현
- [x] 면접 기록 삭제 기능 구현 (모달 확인 다이얼로그 포함)
- [x] 면접 결과 페이지에 피드백 및 삭제 기능 통합

---

## 🤔 주요 고민 및 해결 과정 (선택)

**[ UX 개선: alert ]**

- **문제점**: alert사용 시 브라우저 네이티브 대화상자로 UX가 떨어짐
- **해결 과정**: 커스텀 모달 다이얼로그로 대체하여 일관된 UI/UX 제공

**[ 피드백 에러 처리 ]**

- **문제점**: 좋아요/싫어요 실패 시 사용자에게 피드백 필요
- **해결 과정**: 인라인 에러 메시지 (빨간 배경, AlertCircle 아이콘)와 자동 해제 (3초) 적용하여 자연스러운 UX 구현

---

## 💬 리뷰어에게

- 삭제 버튼 클릭 시 모달이 표시되며, 면접 기록 삭제 후 홈(`/`)으로 이동합니다
- 피드백 버튼은 여러 번 클릭 가능하도록 설정했습니다 (disabled 처리 없음)
